### PR TITLE
Don't swallow Reason parsing errors

### DIFF
--- a/jscomp/syntax/ast_reason_pp.ml
+++ b/jscomp/syntax/ast_reason_pp.ml
@@ -36,7 +36,10 @@ exception Pp_error
    Location.init lexbuf filename;
    parser lexbuf
   with
-  | _ -> raise Pp_error
+  | Reason_errors.Reason_error _ as rexn ->
+    raise rexn
+  | _ ->
+      raise Pp_error
 
  let parse_implementation filename =
    let omp_ast = setup_lexbuf

--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -3,7 +3,7 @@
 let
   overlays =
     builtins.fetchTarball
-      https://github.com/anmonteiro/nix-overlays/archive/34a5399.tar.gz;
+      https://github.com/anmonteiro/nix-overlays/archive/b850b3e.tar.gz;
 
 in
 


### PR DESCRIPTION
somewhat unbelivably, BuckleScript made a change
(https://github.com/rescript-lang/rescript-compiler/commit/1d5c782ed)
around the time we landed the re-error diff that resulted in swallowing
_all_ Reason syntax errors and returning a generic syntax error instead.