### PR TITLE
Fix namespaces

### DIFF
--- a/jscomp/bsb/bsb_ninja_gen.ml
+++ b/jscomp/bsb/bsb_ninja_gen.ml
@@ -278,7 +278,8 @@ let output_ninja_and_namespace_map
   Buffer.add_char buf '\n';
   Ext_option.iter  namespace (fun ns ->
       let namespace_dir =
-        per_proj_dir // lib_artifacts_dir  in
+        Ext_path.rel_normalized_absolute_path ~from:root_dir (per_proj_dir // lib_artifacts_dir)
+      in
       Bsb_namespace_map_gen.output
         ~dir:namespace_dir ns
         bs_file_groups;

--- a/jscomp/bsb/bsb_ninja_rule.ml
+++ b/jscomp/bsb/bsb_ninja_rule.ml
@@ -284,7 +284,9 @@ let make_custom_rules
          let s = global_config.bsc ^ Ext_string.single_space ^ stdlib_incl ^
          " -w -49 -color always -no-alias-deps %{inputs}"
          in
-        Buffer.add_string buf s)
+        Buffer.add_string buf "(action (run ";
+        Buffer.add_string buf s;
+        Buffer.add_string buf "))")
       ~restat:()
       "build_package"
   in


### PR DESCRIPTION
- generate `(subdir` rules with a relative directory, otherwise dune segfaults
- add missing `(action (run` to the rule that builds the NS package


#### What's missing?

Ideally we avoid generating the `lib/bs` directory altogether, and especially the namespace stuff there. That will enable out of source builds.