### PR TITLE
Fix bs-dev-dependencies

### DIFF
--- a/jscomp/bsb/bsb_ninja_file_groups.mli
+++ b/jscomp/bsb/bsb_ninja_file_groups.mli
@@ -33,5 +33,6 @@ val handle_files_per_dir :
   package_specs:Bsb_package_specs.t ->
   js_post_build_cmd:string option ->
   files_to_install:Bsb_db.module_info Queue.t ->
-  bs_dependencies_deps:string list ->
+  bs_dependencies:string list ->
+  bs_dev_dependencies:string list ->
   Bsb_file_groups.file_group -> unit

--- a/jscomp/bsb/bsb_ninja_gen.ml
+++ b/jscomp/bsb/bsb_ninja_gen.ml
@@ -251,8 +251,11 @@ let output_ninja_and_namespace_map
       ~reason_react_jsx
       ~package_specs
       generators in
-  let bs_dependencies_deps =
+  let bs_dependencies =
    Ext_list.flat_map bs_dependencies (fun { Bsb_config_types.package_dirs; _ } -> package_dirs)
+  in
+  let bs_dev_dependencies =
+   Ext_list.flat_map bs_dev_dependencies (fun { Bsb_config_types.package_dirs; _ } -> package_dirs)
   in
   Buffer.add_char buf '\n';
 
@@ -267,7 +270,8 @@ let output_ninja_and_namespace_map
          ~package_specs
          ~files_to_install
          ~js_post_build_cmd
-         ~bs_dependencies_deps
+         ~bs_dev_dependencies
+         ~bs_dependencies
          ~root_dir
          files_per_dir;
          )

--- a/jscomp/bsb/bsb_ninja_targets.ml
+++ b/jscomp/bsb/bsb_ninja_targets.ml
@@ -156,7 +156,7 @@ let output_alias ?action buf ~name ~deps =
 let output_build
     ?(implicit_deps=[])
     ?(rel_deps=[])
-    ?(bs_dependencies_deps=[])
+    ?(bs_dependencies=[])
     ?(implicit_outputs=[])
     ?(js_outputs=[])
     ~outputs
@@ -196,8 +196,8 @@ let output_build
         Buffer.add_string buf (Filename.basename s))
   end;
   Ext_list.iter rel_deps (fun s -> Buffer.add_string buf Ext_string.single_space; Buffer.add_string buf s);
-  if bs_dependencies_deps <> [] then
-    Ext_list.iter bs_dependencies_deps (fun dir ->
+  if bs_dependencies <> [] then
+    Ext_list.iter bs_dependencies (fun dir ->
       Buffer.add_string buf "(alias "; Buffer.add_string buf dir; Buffer.add_string buf ")";
     );
   Buffer.add_string buf ")";

--- a/jscomp/bsb/bsb_ninja_targets.mli
+++ b/jscomp/bsb/bsb_ninja_targets.mli
@@ -36,7 +36,7 @@ val output_alias :
 val output_build :
   ?implicit_deps:string list ->
   ?rel_deps:string list ->
-  ?bs_dependencies_deps:string list ->
+  ?bs_dependencies:string list ->
   ?implicit_outputs: string list ->
   ?js_outputs: (string * bool) list ->
   outputs:string list ->


### PR DESCRIPTION
fixes #23 

- we were emitting rules for the `bs-dev-dependencies`, but not depending on them in the dev source dirs.