### PR TITLE
Fix a codegen bug related to `Ident.t` and recursion

### DIFF
--- a/jscomp/ext/ext_ident.ml
+++ b/jscomp/ext/ext_ident.ml
@@ -75,7 +75,7 @@ let make_js_object (i : Ident.t) =
    ~scope:(Ident.scope i lor js_object_flag)
    (Ident.name i)
 
-(* `create_js` creates an ident that has been described to as by the JS FFI. In
+(* `create_js` creates an ident that has been described to us by the JS FFI. In
    OCaml 4.06 and below, the `Ident.t` type abused `flags` and `stamp` to mark
    it as such ("global" values had a stamp of 0). After PR#1980 to OCaml, not
    only has the `Ident.t` type been made abstract, but also the `Global of

--- a/jscomp/ext/ext_ident.ml
+++ b/jscomp/ext/ext_ident.ml
@@ -75,9 +75,12 @@ let make_js_object (i : Ident.t) =
    ~scope:(Ident.scope i lor js_object_flag)
    (Ident.name i)
 
-(* It's a js function hard coded by js api, so when printing,
-   it should preserve the name
-*)
+(* `create_js` creates an ident that has been described to as by the JS FFI. In
+   OCaml 4.06 and below, the `Ident.t` type abused `flags` and `stamp` to mark
+   it as such ("global" values had a stamp of 0). After PR#1980 to OCaml, not
+   only has the `Ident.t` type been made abstract, but also the `Global of
+   string` constructor stopped taking "flags" (which we need to mark the value
+   as coming from the JS FFI). *)
 let create_js (name : string) : Ident.t  =
   create_unsafe_dont_use_or_bad_things_will_happen ~stamp:0 ~scope:js_flag name
 


### PR DESCRIPTION
This is the 2nd part of #23 (thanks @TheSpyder!).

The bug was easily reproduced with:

```ocaml
external describe : string -> unit = "describe" [@@bs.val ]

let describe = describe
```

Before this fix, the generated code looked like:

```js
function describe(prim) {
  describe(prim);
}

exports.describe = describe;
```

After the fix:

```js
function describe$1(prim) {
  describe(prim);

}

exports.describe = describe$1;
```