### PR TITLE
Fix CI on Windows, builds bsc and bsb

### DIFF
--- a/jscomp/bsb/bsb_global_paths.ml
+++ b/jscomp/bsb/bsb_global_paths.ml
@@ -56,7 +56,7 @@ let vendor_ninja = "ninja.exe"
 
 let vendor_bsdep = "bsb_helper.exe"
 
-let bs_dep_parse = "bsb_parse_depend.exe"
+let bs_dep_parse = "bsb_parse_depend"
 
 
 ;; assert (Sys.file_exists bsc_dir)

--- a/jscomp/bsb/bsb_global_paths.ml
+++ b/jscomp/bsb/bsb_global_paths.ml
@@ -54,7 +54,7 @@ let vendor_bsc = "bsc"
 
 let vendor_ninja = "ninja.exe"
 
-let vendor_bsdep = "bsb_helper.exe"
+let vendor_bsdep = "bsb_helper"
 
 let bs_dep_parse = "bsb_parse_depend"
 

--- a/jscomp/bsb/bsb_global_paths.ml
+++ b/jscomp/bsb/bsb_global_paths.ml
@@ -50,7 +50,7 @@ let bsc_dir  =
     (Ext_path.normalize_absolute_path
        (Ext_path.combine cwd  Sys.executable_name))
 
-let vendor_bsc = "bsc.exe"
+let vendor_bsc = "bsc"
 
 let vendor_ninja = "ninja.exe"
 

--- a/jscomp/bsb/bsb_ninja_file_groups.ml
+++ b/jscomp/bsb/bsb_ninja_file_groups.ml
@@ -173,7 +173,7 @@ let emit_module_build
      (if has_intf_file then [] else [ output_cmi ])
     ~js_outputs:output_js
     ~inputs:[output_ast]
-    ~implicit_deps:(if has_intf_file then [output_cmi; output_d_as_dep] else [output_d_as_dep])
+    ~implicit_deps:(if has_intf_file then [(Filename.basename output_cmi); output_d_as_dep] else [output_d_as_dep])
     ~bs_dependencies
     ~rel_deps:(rel_bs_config_json :: relative_ns_cmi)
     ~rule;

--- a/jscomp/bsb/bsb_ninja_gen.ml
+++ b/jscomp/bsb/bsb_ninja_gen.ml
@@ -208,7 +208,7 @@ let output_ninja_and_namespace_map
     ) in
   let g_stdlib_incl = if built_in_dependency then
       let path = Bsb_config.stdlib_path ~cwd:per_proj_dir in
-      [ Ext_filename.maybe_quote path ]
+      [ path ]
     else []
   in
   let global_config =

--- a/jscomp/bsb/bsb_ninja_targets.ml
+++ b/jscomp/bsb/bsb_ninja_targets.ml
@@ -193,7 +193,7 @@ let output_build
   if implicit_deps <> [] then begin
       Ext_list.iter implicit_deps (fun s ->
         Buffer.add_string buf Ext_string.single_space;
-        Buffer.add_string buf (Filename.basename s))
+        Buffer.add_string buf s)
   end;
   Ext_list.iter rel_deps (fun s -> Buffer.add_string buf Ext_string.single_space; Buffer.add_string buf s);
   if bs_dependencies <> [] then

--- a/jscomp/main/dune
+++ b/jscomp/main/dune
@@ -35,7 +35,7 @@
 
 (executable
  (name bspack_main)
- (public_name bspack.exe)
+ (public_name bspack)
  (modes native)
  (modules bspack_main)
  (flags

--- a/jscomp/main/dune
+++ b/jscomp/main/dune
@@ -35,7 +35,7 @@
   ../../bsconfig.json)
  (action
   (progn
-   (system "mkdir -p %{workspace_root}/lib/es6 %{workspace_root}/lib/js")
+   (bash "mkdir -p %{workspace_root}/lib/es6 %{workspace_root}/lib/js")
    (run cppo %{env:CPPO_FLAGS=} %{input} -o %{target}))))
 
 (executable

--- a/jscomp/main/dune
+++ b/jscomp/main/dune
@@ -4,7 +4,7 @@
 
 (executable
  (name bsc)
- (public_name bsc.exe)
+ (public_name bsc)
  (modes native)
  (flags
   (:standard -w -9))
@@ -21,11 +21,6 @@
   reason)
  (modules_without_implementation jscmj_main)
  (modules bsc jscmj_main))
-
-(install
- (files
-  (bsc.exe as bsc))
- (section bin))
 
 (rule
  (target bsc.ml)

--- a/jscomp/main/dune
+++ b/jscomp/main/dune
@@ -44,17 +44,12 @@
 
 (executable
  (name bsb_main)
- (public_name bsb.exe)
+ (public_name bsb)
  (modes native)
  (modules bsb_main)
  (flags
   (:standard -w -9-50))
  (libraries bs_hash_stubs ext common bsb))
-
-(install
- (files
-  (bsb_main.exe as bsb))
- (section bin))
 
 (executable
  (name cmjdump_main)

--- a/jscomp/main/dune
+++ b/jscomp/main/dune
@@ -1,7 +1,3 @@
-(install
- (section bin)
- (files bsb_helper.exe))
-
 (executable
  (name bsc)
  (public_name bsc)
@@ -67,15 +63,10 @@
 
 (executable
  (name bsb_helper_main)
+ (public_name bsb_helper)
  (modes native)
  (modules bsb_helper_main)
  (libraries bsb_helper bs_hash_stubs ext common depends core))
-
-(rule
- (target bsb_helper.exe)
- (deps bsb_helper_main.exe)
- (action
-  (copy %{deps} %{target})))
 
 (executable
  (name bsb_parse_depend)

--- a/jscomp/main/dune
+++ b/jscomp/main/dune
@@ -79,7 +79,7 @@
 
 (executable
  (name bsb_parse_depend)
- (public_name bsb_parse_depend.exe)
+ (public_name bsb_parse_depend)
  (modes native)
  (modules bsb_parse_depend)
  (libraries bsb ext dune-action-plugin))

--- a/jscomp/others/dune.gen
+++ b/jscomp/others/dune.gen
@@ -347,294 +347,294 @@
     (targets belt.cmj belt.cmi)
     (deps (:inputs belt.ml) (alias ../runtime/runtime))
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets node.cmj node.cmi)
     (deps (:inputs node.ml) (alias ../runtime/runtime))
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets js_OO.cmi js_OO.cmj)
     (deps (:inputs js_OO.ml) (alias ../runtime/runtime))
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets js_array.cmi js_array.cmj)
     (deps (:inputs js_array.ml) (alias ../runtime/runtime) js_array2.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets js_array2.cmi js_array2.cmj)
     (deps (:inputs js_array2.ml) (alias ../runtime/runtime))
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets js_cast.cmj)
     (deps (:inputs js_cast.ml) (alias ../runtime/runtime) js_cast.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets js_cast.cmi)
     (deps (:inputs js_cast.mli) (alias ../runtime/runtime))
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets js_console.cmi js_console.cmj)
     (deps (:inputs js_console.ml) (alias ../runtime/runtime))
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets js_date.cmi js_date.cmj)
     (deps (:inputs js_date.ml) (alias ../runtime/runtime))
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets js_dict.cmj)
     (deps (:inputs js_dict.ml) (alias ../runtime/runtime) js_array2.cmj js_dict.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets js_dict.cmi)
     (deps (:inputs js_dict.mli) (alias ../runtime/runtime))
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets js_exn.cmj)
     (deps (:inputs js_exn.ml) (alias ../runtime/runtime) js_exn.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets js_exn.cmi)
     (deps (:inputs js_exn.mli) (alias ../runtime/runtime))
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets js_float.cmi js_float.cmj)
     (deps (:inputs js_float.ml) (alias ../runtime/runtime))
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets js_global.cmi js_global.cmj)
     (deps (:inputs js_global.ml) (alias ../runtime/runtime))
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets js_int.cmi js_int.cmj)
     (deps (:inputs js_int.ml) (alias ../runtime/runtime))
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets js_json.cmj)
     (deps (:inputs js_json.ml) (alias ../runtime/runtime) js_array2.cmj js_dict.cmj js_json.cmi js_string.cmj js_types.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets js_json.cmi)
     (deps (:inputs js_json.mli) (alias ../runtime/runtime) js_dict.cmi js_null.cmi js_string.cmj js_types.cmi)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets js_list.cmj)
     (deps (:inputs js_list.ml) (alias ../runtime/runtime) js_array2.cmj js_list.cmi js_vector.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets js_list.cmi)
     (deps (:inputs js_list.mli) (alias ../runtime/runtime) js_vector.cmi)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets js_mapperRt.cmj)
     (deps (:inputs js_mapperRt.ml) (alias ../runtime/runtime) js_mapperRt.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets js_mapperRt.cmi)
     (deps (:inputs js_mapperRt.mli) (alias ../runtime/runtime))
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets js_math.cmi js_math.cmj)
     (deps (:inputs js_math.ml) (alias ../runtime/runtime) js_int.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets js_null.cmj)
     (deps (:inputs js_null.ml) (alias ../runtime/runtime) js_exn.cmj js_null.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets js_null.cmi)
     (deps (:inputs js_null.mli) (alias ../runtime/runtime))
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets js_null_undefined.cmj)
     (deps (:inputs js_null_undefined.ml) (alias ../runtime/runtime) js_null_undefined.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets js_null_undefined.cmi)
     (deps (:inputs js_null_undefined.mli) (alias ../runtime/runtime))
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets js_obj.cmi js_obj.cmj)
     (deps (:inputs js_obj.ml) (alias ../runtime/runtime))
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets js_option.cmj)
     (deps (:inputs js_option.ml) (alias ../runtime/runtime) js_exn.cmj js_option.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets js_option.cmi)
     (deps (:inputs js_option.mli) (alias ../runtime/runtime))
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets js_promise.cmi js_promise.cmj)
     (deps (:inputs js_promise.ml) (alias ../runtime/runtime))
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets js_re.cmi js_re.cmj)
     (deps (:inputs js_re.ml) (alias ../runtime/runtime))
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets js_result.cmj)
     (deps (:inputs js_result.ml) (alias ../runtime/runtime) js_result.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets js_result.cmi)
     (deps (:inputs js_result.mli) (alias ../runtime/runtime))
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets js_string.cmi js_string.cmj)
     (deps (:inputs js_string.ml) (alias ../runtime/runtime) js_array2.cmj js_re.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets js_string2.cmi js_string2.cmj)
     (deps (:inputs js_string2.ml) (alias ../runtime/runtime) js_array2.cmj js_re.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets js_types.cmj)
     (deps (:inputs js_types.ml) (alias ../runtime/runtime) js_null.cmj js_types.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets js_types.cmi)
     (deps (:inputs js_types.mli) (alias ../runtime/runtime))
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets js_undefined.cmj)
     (deps (:inputs js_undefined.ml) (alias ../runtime/runtime) js_exn.cmj js_undefined.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets js_undefined.cmi)
     (deps (:inputs js_undefined.mli) (alias ../runtime/runtime))
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets js_vector.cmj)
     (deps (:inputs js_vector.ml) (alias ../runtime/runtime) js_array2.cmj js_vector.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets js_vector.cmi)
     (deps (:inputs js_vector.mli) (alias ../runtime/runtime))
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
     (alias
@@ -646,644 +646,644 @@
     (targets belt_Array.cmj)
     (deps (:inputs belt_Array.ml) (alias ../runtime/runtime) belt.cmi belt_Array.cmi js_math.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_Array.cmi)
     (deps (:inputs belt_Array.mli) (alias ../runtime/runtime))
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_Float.cmj)
     (deps (:inputs belt_Float.ml) (alias ../runtime/runtime) belt.cmi belt_Float.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_Float.cmi)
     (deps (:inputs belt_Float.mli) (alias ../runtime/runtime))
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_HashMap.cmj)
     (deps (:inputs belt_HashMap.ml) (alias ../runtime/runtime) (alias js_pkg) belt.cmi belt_Array.cmj belt_HashMap.cmi belt_HashMapInt.cmi belt_HashMapInt.cmj belt_HashMapString.cmi belt_HashMapString.cmj belt_Id.cmj belt_internalBuckets.cmj belt_internalBucketsType.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_HashMap.cmi)
     (deps (:inputs belt_HashMap.mli) (alias ../runtime/runtime) (alias js_pkg) belt.cmi belt_HashMapInt.cmi belt_HashMapInt.cmj belt_HashMapString.cmi belt_HashMapString.cmj belt_Id.cmi)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_HashMapInt.cmj)
     (deps (:inputs belt_HashMapInt.ml) (alias ../runtime/runtime) (alias js_pkg) belt.cmi belt_Array.cmi belt_Array.cmj belt_HashMapInt.cmi belt_internalBuckets.cmi belt_internalBuckets.cmj belt_internalBucketsType.cmi belt_internalBucketsType.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_HashMapInt.cmi)
     (deps (:inputs belt_HashMapInt.mli) (alias ../runtime/runtime) (alias js_pkg) belt_Array.cmi belt_Array.cmj belt_internalBuckets.cmi belt_internalBuckets.cmj belt_internalBucketsType.cmi belt_internalBucketsType.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_HashMapString.cmj)
     (deps (:inputs belt_HashMapString.ml) (alias ../runtime/runtime) (alias js_pkg) belt.cmi belt_Array.cmi belt_Array.cmj belt_HashMapString.cmi belt_internalBuckets.cmi belt_internalBuckets.cmj belt_internalBucketsType.cmi belt_internalBucketsType.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_HashMapString.cmi)
     (deps (:inputs belt_HashMapString.mli) (alias ../runtime/runtime) (alias js_pkg) belt_Array.cmi belt_Array.cmj belt_internalBuckets.cmi belt_internalBuckets.cmj belt_internalBucketsType.cmi belt_internalBucketsType.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_HashSet.cmj)
     (deps (:inputs belt_HashSet.ml) (alias ../runtime/runtime) (alias js_pkg) belt.cmi belt_Array.cmj belt_HashSet.cmi belt_HashSetInt.cmi belt_HashSetInt.cmj belt_HashSetString.cmi belt_HashSetString.cmj belt_Id.cmj belt_internalBucketsType.cmj belt_internalSetBuckets.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_HashSet.cmi)
     (deps (:inputs belt_HashSet.mli) (alias ../runtime/runtime) (alias js_pkg) belt.cmi belt_HashSetInt.cmi belt_HashSetInt.cmj belt_HashSetString.cmi belt_HashSetString.cmj belt_Id.cmi)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_HashSetInt.cmj)
     (deps (:inputs belt_HashSetInt.ml) (alias ../runtime/runtime) (alias js_pkg) belt.cmi belt_Array.cmi belt_Array.cmj belt_HashSetInt.cmi belt_internalBucketsType.cmi belt_internalBucketsType.cmj belt_internalSetBuckets.cmi belt_internalSetBuckets.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_HashSetInt.cmi)
     (deps (:inputs belt_HashSetInt.mli) (alias ../runtime/runtime) (alias js_pkg) belt_Array.cmi belt_Array.cmj belt_internalBucketsType.cmi belt_internalBucketsType.cmj belt_internalSetBuckets.cmi belt_internalSetBuckets.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_HashSetString.cmj)
     (deps (:inputs belt_HashSetString.ml) (alias ../runtime/runtime) (alias js_pkg) belt.cmi belt_Array.cmi belt_Array.cmj belt_HashSetString.cmi belt_internalBucketsType.cmi belt_internalBucketsType.cmj belt_internalSetBuckets.cmi belt_internalSetBuckets.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_HashSetString.cmi)
     (deps (:inputs belt_HashSetString.mli) (alias ../runtime/runtime) (alias js_pkg) belt_Array.cmi belt_Array.cmj belt_internalBucketsType.cmi belt_internalBucketsType.cmj belt_internalSetBuckets.cmi belt_internalSetBuckets.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_Id.cmj)
     (deps (:inputs belt_Id.ml) (alias ../runtime/runtime) belt.cmi belt_Id.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_Id.cmi)
     (deps (:inputs belt_Id.mli) (alias ../runtime/runtime))
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_Int.cmj)
     (deps (:inputs belt_Int.ml) (alias ../runtime/runtime) belt.cmi belt_Int.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_Int.cmi)
     (deps (:inputs belt_Int.mli) (alias ../runtime/runtime))
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_List.cmj)
     (deps (:inputs belt_List.ml) (alias ../runtime/runtime) belt.cmi belt_Array.cmj belt_List.cmi belt_SortArray.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_List.cmi)
     (deps (:inputs belt_List.mli) (alias ../runtime/runtime))
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_Map.cmj)
     (deps (:inputs belt_Map.ml) (alias ../runtime/runtime) (alias js_pkg) belt.cmi belt_Id.cmj belt_Map.cmi belt_MapDict.cmj belt_MapInt.cmi belt_MapInt.cmj belt_MapString.cmi belt_MapString.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_Map.cmi)
     (deps (:inputs belt_Map.mli) (alias ../runtime/runtime) (alias js_pkg) belt.cmi belt_Id.cmi belt_MapDict.cmi belt_MapInt.cmi belt_MapInt.cmj belt_MapString.cmi belt_MapString.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_MapDict.cmj)
     (deps (:inputs belt_MapDict.ml) (alias ../runtime/runtime) belt.cmi belt_Array.cmj belt_Id.cmj belt_MapDict.cmi belt_internalAVLtree.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_MapDict.cmi)
     (deps (:inputs belt_MapDict.mli) (alias ../runtime/runtime) belt.cmi belt_Id.cmi)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_MapInt.cmj)
     (deps (:inputs belt_MapInt.ml) (alias ../runtime/runtime) (alias js_pkg) belt.cmi belt_Array.cmi belt_Array.cmj belt_MapInt.cmi belt_internalAVLtree.cmi belt_internalAVLtree.cmj belt_internalMapInt.cmi belt_internalMapInt.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_MapInt.cmi)
     (deps (:inputs belt_MapInt.mli) (alias ../runtime/runtime) (alias js_pkg) belt_Array.cmi belt_Array.cmj belt_internalAVLtree.cmi belt_internalAVLtree.cmj belt_internalMapInt.cmi belt_internalMapInt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_MapString.cmj)
     (deps (:inputs belt_MapString.ml) (alias ../runtime/runtime) (alias js_pkg) belt.cmi belt_Array.cmi belt_Array.cmj belt_MapString.cmi belt_internalAVLtree.cmi belt_internalAVLtree.cmj belt_internalMapString.cmi belt_internalMapString.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_MapString.cmi)
     (deps (:inputs belt_MapString.mli) (alias ../runtime/runtime) (alias js_pkg) belt_Array.cmi belt_Array.cmj belt_internalAVLtree.cmi belt_internalAVLtree.cmj belt_internalMapString.cmi belt_internalMapString.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_MutableMap.cmj)
     (deps (:inputs belt_MutableMap.ml) (alias ../runtime/runtime) (alias js_pkg) belt.cmi belt_Array.cmj belt_Id.cmj belt_MutableMap.cmi belt_MutableMapInt.cmi belt_MutableMapInt.cmj belt_MutableMapString.cmi belt_MutableMapString.cmj belt_internalAVLtree.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_MutableMap.cmi)
     (deps (:inputs belt_MutableMap.mli) (alias ../runtime/runtime) (alias js_pkg) belt.cmi belt_Id.cmi belt_MutableMapInt.cmi belt_MutableMapInt.cmj belt_MutableMapString.cmi belt_MutableMapString.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_MutableMapInt.cmj)
     (deps (:inputs belt_MutableMapInt.ml) (alias ../runtime/runtime) (alias js_pkg) belt.cmi belt_Array.cmi belt_Array.cmj belt_MutableMapInt.cmi belt_internalAVLtree.cmi belt_internalAVLtree.cmj belt_internalMapInt.cmi belt_internalMapInt.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_MutableMapInt.cmi)
     (deps (:inputs belt_MutableMapInt.mli) (alias ../runtime/runtime) (alias js_pkg) belt_Array.cmi belt_Array.cmj belt_internalAVLtree.cmi belt_internalAVLtree.cmj belt_internalMapInt.cmi belt_internalMapInt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_MutableMapString.cmj)
     (deps (:inputs belt_MutableMapString.ml) (alias ../runtime/runtime) (alias js_pkg) belt.cmi belt_Array.cmi belt_Array.cmj belt_MutableMapString.cmi belt_internalAVLtree.cmi belt_internalAVLtree.cmj belt_internalMapString.cmi belt_internalMapString.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_MutableMapString.cmi)
     (deps (:inputs belt_MutableMapString.mli) (alias ../runtime/runtime) (alias js_pkg) belt_Array.cmi belt_Array.cmj belt_internalAVLtree.cmi belt_internalAVLtree.cmj belt_internalMapString.cmi belt_internalMapString.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_MutableQueue.cmj)
     (deps (:inputs belt_MutableQueue.ml) (alias ../runtime/runtime) belt.cmi belt_Array.cmj belt_MutableQueue.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_MutableQueue.cmi)
     (deps (:inputs belt_MutableQueue.mli) (alias ../runtime/runtime))
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_MutableSet.cmj)
     (deps (:inputs belt_MutableSet.ml) (alias ../runtime/runtime) (alias js_pkg) belt.cmi belt_Array.cmj belt_Id.cmj belt_MutableSet.cmi belt_MutableSetInt.cmi belt_MutableSetInt.cmj belt_MutableSetString.cmi belt_MutableSetString.cmj belt_SortArray.cmj belt_internalAVLset.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_MutableSet.cmi)
     (deps (:inputs belt_MutableSet.mli) (alias ../runtime/runtime) (alias js_pkg) belt.cmi belt_Id.cmi belt_MutableSetInt.cmi belt_MutableSetInt.cmj belt_MutableSetString.cmi belt_MutableSetString.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_MutableSetInt.cmj)
     (deps (:inputs belt_MutableSetInt.ml) (alias ../runtime/runtime) (alias js_pkg) belt.cmi belt_Array.cmi belt_Array.cmj belt_MutableSetInt.cmi belt_SortArrayInt.cmi belt_SortArrayInt.cmj belt_internalAVLset.cmi belt_internalAVLset.cmj belt_internalSetInt.cmi belt_internalSetInt.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_MutableSetInt.cmi)
     (deps (:inputs belt_MutableSetInt.mli) (alias ../runtime/runtime) (alias js_pkg) belt_Array.cmi belt_Array.cmj belt_SortArrayInt.cmi belt_SortArrayInt.cmj belt_internalAVLset.cmi belt_internalAVLset.cmj belt_internalSetInt.cmi belt_internalSetInt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_MutableSetString.cmj)
     (deps (:inputs belt_MutableSetString.ml) (alias ../runtime/runtime) (alias js_pkg) belt.cmi belt_Array.cmi belt_Array.cmj belt_MutableSetString.cmi belt_SortArrayString.cmi belt_SortArrayString.cmj belt_internalAVLset.cmi belt_internalAVLset.cmj belt_internalSetString.cmi belt_internalSetString.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_MutableSetString.cmi)
     (deps (:inputs belt_MutableSetString.mli) (alias ../runtime/runtime) (alias js_pkg) belt_Array.cmi belt_Array.cmj belt_SortArrayString.cmi belt_SortArrayString.cmj belt_internalAVLset.cmi belt_internalAVLset.cmj belt_internalSetString.cmi belt_internalSetString.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_MutableStack.cmj)
     (deps (:inputs belt_MutableStack.ml) (alias ../runtime/runtime) belt.cmi belt_MutableStack.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_MutableStack.cmi)
     (deps (:inputs belt_MutableStack.mli) (alias ../runtime/runtime))
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_Option.cmj)
     (deps (:inputs belt_Option.ml) (alias ../runtime/runtime) belt.cmi belt_Option.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_Option.cmi)
     (deps (:inputs belt_Option.mli) (alias ../runtime/runtime))
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_Range.cmj)
     (deps (:inputs belt_Range.ml) (alias ../runtime/runtime) belt.cmi belt_Range.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_Range.cmi)
     (deps (:inputs belt_Range.mli) (alias ../runtime/runtime))
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_Result.cmj)
     (deps (:inputs belt_Result.ml) (alias ../runtime/runtime) belt.cmi belt_Result.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_Result.cmi)
     (deps (:inputs belt_Result.mli) (alias ../runtime/runtime))
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_Set.cmj)
     (deps (:inputs belt_Set.ml) (alias ../runtime/runtime) (alias js_pkg) belt.cmi belt_Id.cmj belt_Set.cmi belt_SetDict.cmj belt_SetInt.cmi belt_SetInt.cmj belt_SetString.cmi belt_SetString.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_Set.cmi)
     (deps (:inputs belt_Set.mli) (alias ../runtime/runtime) (alias js_pkg) belt.cmi belt_Id.cmi belt_SetDict.cmi belt_SetInt.cmi belt_SetInt.cmj belt_SetString.cmi belt_SetString.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_SetDict.cmj)
     (deps (:inputs belt_SetDict.ml) (alias ../runtime/runtime) belt.cmi belt_Array.cmj belt_Id.cmj belt_SetDict.cmi belt_internalAVLset.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_SetDict.cmi)
     (deps (:inputs belt_SetDict.mli) (alias ../runtime/runtime) belt.cmi belt_Id.cmi)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_SetInt.cmj)
     (deps (:inputs belt_SetInt.ml) (alias ../runtime/runtime) (alias js_pkg) belt.cmi belt_Array.cmi belt_Array.cmj belt_SetInt.cmi belt_internalAVLset.cmi belt_internalAVLset.cmj belt_internalSetInt.cmi belt_internalSetInt.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_SetInt.cmi)
     (deps (:inputs belt_SetInt.mli) (alias ../runtime/runtime) (alias js_pkg) belt_Array.cmi belt_Array.cmj belt_internalAVLset.cmi belt_internalAVLset.cmj belt_internalSetInt.cmi belt_internalSetInt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_SetString.cmj)
     (deps (:inputs belt_SetString.ml) (alias ../runtime/runtime) (alias js_pkg) belt.cmi belt_Array.cmi belt_Array.cmj belt_SetString.cmi belt_internalAVLset.cmi belt_internalAVLset.cmj belt_internalSetString.cmi belt_internalSetString.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_SetString.cmi)
     (deps (:inputs belt_SetString.mli) (alias ../runtime/runtime) (alias js_pkg) belt_Array.cmi belt_Array.cmj belt_internalAVLset.cmi belt_internalAVLset.cmj belt_internalSetString.cmi belt_internalSetString.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_SortArray.cmj)
     (deps (:inputs belt_SortArray.ml) (alias ../runtime/runtime) (alias js_pkg) belt.cmi belt_Array.cmj belt_SortArray.cmi belt_SortArrayInt.cmi belt_SortArrayInt.cmj belt_SortArrayString.cmi belt_SortArrayString.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_SortArray.cmi)
     (deps (:inputs belt_SortArray.mli) (alias ../runtime/runtime) (alias js_pkg) belt.cmi belt_SortArrayInt.cmi belt_SortArrayInt.cmj belt_SortArrayString.cmi belt_SortArrayString.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_SortArrayInt.cmj)
     (deps (:inputs belt_SortArrayInt.ml) (alias ../runtime/runtime) (alias js_pkg) belt.cmi belt_Array.cmi belt_Array.cmj belt_SortArrayInt.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_SortArrayInt.cmi)
     (deps (:inputs belt_SortArrayInt.mli) (alias ../runtime/runtime) (alias js_pkg) belt_Array.cmi belt_Array.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_SortArrayString.cmj)
     (deps (:inputs belt_SortArrayString.ml) (alias ../runtime/runtime) (alias js_pkg) belt.cmi belt_Array.cmi belt_Array.cmj belt_SortArrayString.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_SortArrayString.cmi)
     (deps (:inputs belt_SortArrayString.mli) (alias ../runtime/runtime) (alias js_pkg) belt_Array.cmi belt_Array.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_internalAVLset.cmj)
     (deps (:inputs belt_internalAVLset.ml) (alias ../runtime/runtime) belt.cmi belt_Array.cmj belt_Id.cmj belt_SortArray.cmj belt_internalAVLset.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_internalAVLset.cmi)
     (deps (:inputs belt_internalAVLset.mli) (alias ../runtime/runtime) belt.cmi belt_Id.cmi)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_internalAVLtree.cmj)
     (deps (:inputs belt_internalAVLtree.ml) (alias ../runtime/runtime) belt.cmi belt_Array.cmj belt_Id.cmj belt_SortArray.cmj belt_internalAVLtree.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_internalAVLtree.cmi)
     (deps (:inputs belt_internalAVLtree.mli) (alias ../runtime/runtime) belt.cmi belt_Id.cmi)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_internalBuckets.cmj)
     (deps (:inputs belt_internalBuckets.ml) (alias ../runtime/runtime) belt.cmi belt_Array.cmj belt_internalBuckets.cmi belt_internalBucketsType.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_internalBuckets.cmi)
     (deps (:inputs belt_internalBuckets.mli) (alias ../runtime/runtime) belt.cmi belt_internalBucketsType.cmi)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_internalBucketsType.cmj)
     (deps (:inputs belt_internalBucketsType.ml) (alias ../runtime/runtime) belt.cmi belt_Array.cmj belt_internalBucketsType.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_internalBucketsType.cmi)
     (deps (:inputs belt_internalBucketsType.mli) (alias ../runtime/runtime))
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_internalMapInt.cmi belt_internalMapInt.cmj)
     (deps (:inputs belt_internalMapInt.ml) (alias ../runtime/runtime) (alias js_pkg) belt.cmi belt_Array.cmi belt_Array.cmj belt_SortArray.cmi belt_SortArray.cmj belt_internalAVLtree.cmi belt_internalAVLtree.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_internalMapString.cmi belt_internalMapString.cmj)
     (deps (:inputs belt_internalMapString.ml) (alias ../runtime/runtime) (alias js_pkg) belt.cmi belt_Array.cmi belt_Array.cmj belt_SortArray.cmi belt_SortArray.cmj belt_internalAVLtree.cmi belt_internalAVLtree.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_internalSetBuckets.cmj)
     (deps (:inputs belt_internalSetBuckets.ml) (alias ../runtime/runtime) belt.cmi belt_Array.cmj belt_internalBucketsType.cmj belt_internalSetBuckets.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_internalSetBuckets.cmi)
     (deps (:inputs belt_internalSetBuckets.mli) (alias ../runtime/runtime) belt.cmi belt_internalBucketsType.cmi)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_internalSetInt.cmi belt_internalSetInt.cmj)
     (deps (:inputs belt_internalSetInt.ml) (alias ../runtime/runtime) (alias js_pkg) belt.cmi belt_Array.cmi belt_Array.cmj belt_SortArrayInt.cmi belt_SortArrayInt.cmj belt_internalAVLset.cmi belt_internalAVLset.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets belt_internalSetString.cmi belt_internalSetString.cmj)
     (deps (:inputs belt_internalSetString.ml) (alias ../runtime/runtime) (alias js_pkg) belt.cmi belt_Array.cmi belt_Array.cmj belt_SortArrayString.cmi belt_SortArrayString.cmj belt_internalAVLset.cmi belt_internalAVLset.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets dom.cmi dom.cmj)
     (deps (:inputs dom.ml) (alias ../runtime/runtime) dom_storage.cmj dom_storage2.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets dom_storage.cmi dom_storage.cmj)
     (deps (:inputs dom_storage.ml) (alias ../runtime/runtime) dom_storage2.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets dom_storage2.cmi dom_storage2.cmj)
     (deps (:inputs dom_storage2.ml) (alias ../runtime/runtime))
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets node_buffer.cmi node_buffer.cmj)
     (deps (:inputs node_buffer.ml) (alias ../runtime/runtime) node.cmi node.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets node_child_process.cmi node_child_process.cmj)
     (deps (:inputs node_child_process.ml) (alias ../runtime/runtime) node.cmi node.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets node_fs.cmi node_fs.cmj)
     (deps (:inputs node_fs.ml) (alias ../runtime/runtime) js_string.cmj node.cmi node.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets node_module.cmi node_module.cmj)
     (deps (:inputs node_module.ml) (alias ../runtime/runtime) js_dict.cmj node.cmi node.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets node_path.cmi node_path.cmj)
     (deps (:inputs node_path.ml) (alias ../runtime/runtime))
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets node_process.cmj)
     (deps (:inputs node_process.ml) (alias ../runtime/runtime) js_dict.cmj node.cmi node_process.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets node_process.cmi)
     (deps (:inputs node_process.mli) (alias ../runtime/runtime) js_dict.cmi node.cmi)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets js_typed_array.cmi js_typed_array.cmj)
     (deps (:inputs js_typed_array.ml) (alias ../runtime/runtime) (alias js_pkg) js_typed_array2.cmi js_typed_array2.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
   (rule
     (targets js_typed_array2.cmi js_typed_array2.cmj)
     (deps (:inputs js_typed_array2.ml) (alias ../runtime/runtime))
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A  -open Bs_stdlib_mini -I ../runtime -I . %{inputs})))
 
 
     (alias

--- a/jscomp/runtime/dune.gen
+++ b/jscomp/runtime/dune.gen
@@ -5,392 +5,392 @@
     (targets bs_stdlib_mini.cmi)
     (deps (:inputs bs_stdlib_mini.mli) )
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -nostdlib -nopervasives -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -nostdlib -nopervasives -I . %{inputs})))
 
 
   (rule
     (targets js.cmj js.cmi)
     (deps (:inputs js.ml) )
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -I . %{inputs})))
 
 
   (rule
     (targets caml_array.cmj)
     (deps (:inputs caml_array.ml) caml_array.cmi caml_array_extern.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
 
 
   (rule
     (targets caml_array.cmi)
     (deps (:inputs caml_array.mli) bs_stdlib_mini.cmi js.cmi js.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
 
 
   (rule
     (targets caml_bytes.cmj)
     (deps (:inputs caml_bytes.ml) caml_bytes.cmi caml_string_extern.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
 
 
   (rule
     (targets caml_bytes.cmi)
     (deps (:inputs caml_bytes.mli) bs_stdlib_mini.cmi js.cmi js.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
 
 
   (rule
     (targets caml_float.cmj)
     (deps (:inputs caml_float.ml) caml_float.cmi caml_float_extern.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
 
 
   (rule
     (targets caml_float.cmi)
     (deps (:inputs caml_float.mli) bs_stdlib_mini.cmi js.cmi js.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
 
 
   (rule
     (targets caml_format.cmj)
     (deps (:inputs caml_format.ml) caml_float.cmj caml_float_extern.cmj caml_format.cmi caml_int64.cmj caml_int64_extern.cmj caml_nativeint_extern.cmj caml_string_extern.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
 
 
   (rule
     (targets caml_format.cmi)
     (deps (:inputs caml_format.mli) bs_stdlib_mini.cmi js.cmi js.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
 
 
   (rule
     (targets caml_gc.cmj)
     (deps (:inputs caml_gc.ml) caml_gc.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
 
 
   (rule
     (targets caml_gc.cmi)
     (deps (:inputs caml_gc.mli) bs_stdlib_mini.cmi js.cmi js.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
 
 
   (rule
     (targets caml_hash.cmj)
     (deps (:inputs caml_hash.ml) caml_hash.cmi caml_hash_primitive.cmj caml_nativeint_extern.cmj js.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
 
 
   (rule
     (targets caml_hash.cmi)
     (deps (:inputs caml_hash.mli) bs_stdlib_mini.cmi js.cmi js.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
 
 
   (rule
     (targets caml_hash_primitive.cmj)
     (deps (:inputs caml_hash_primitive.ml) caml_hash_primitive.cmi caml_string_extern.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
 
 
   (rule
     (targets caml_hash_primitive.cmi)
     (deps (:inputs caml_hash_primitive.mli) bs_stdlib_mini.cmi js.cmi js.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
 
 
   (rule
     (targets caml_int32.cmj)
     (deps (:inputs caml_int32.ml) caml_int32.cmi caml_nativeint_extern.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
 
 
   (rule
     (targets caml_int32.cmi)
     (deps (:inputs caml_int32.mli) bs_stdlib_mini.cmi js.cmi js.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
 
 
   (rule
     (targets caml_int64.cmj)
     (deps (:inputs caml_int64.ml) caml_float.cmj caml_float_extern.cmj caml_int64.cmi caml_nativeint_extern.cmj caml_string_extern.cmj js.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
 
 
   (rule
     (targets caml_int64.cmi)
     (deps (:inputs caml_int64.mli) bs_stdlib_mini.cmi js.cmi js.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
 
 
   (rule
     (targets caml_io.cmj)
     (deps (:inputs caml_io.ml) caml_io.cmi caml_string_extern.cmj caml_undefined_extern.cmj js.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
 
 
   (rule
     (targets caml_io.cmi)
     (deps (:inputs caml_io.mli) bs_stdlib_mini.cmi caml_undefined_extern.cmj js.cmi js.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
 
 
   (rule
     (targets caml_lexer.cmj)
     (deps (:inputs caml_lexer.ml) caml_lexer.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
 
 
   (rule
     (targets caml_lexer.cmi)
     (deps (:inputs caml_lexer.mli) bs_stdlib_mini.cmi js.cmi js.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
 
 
   (rule
     (targets caml_md5.cmj)
     (deps (:inputs caml_md5.ml) caml_array_extern.cmj caml_int32_extern.cmj caml_md5.cmi caml_string_extern.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
 
 
   (rule
     (targets caml_md5.cmi)
     (deps (:inputs caml_md5.mli) bs_stdlib_mini.cmi js.cmi js.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
 
 
   (rule
     (targets caml_module.cmj)
     (deps (:inputs caml_module.ml) caml_array_extern.cmj caml_module.cmi caml_obj.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
 
 
   (rule
     (targets caml_module.cmi)
     (deps (:inputs caml_module.mli) bs_stdlib_mini.cmi js.cmi js.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
 
 
   (rule
     (targets caml_obj.cmj)
     (deps (:inputs caml_obj.ml) caml_array_extern.cmj caml_obj.cmi caml_option.cmj caml_primitive.cmj js.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
 
 
   (rule
     (targets caml_obj.cmi)
     (deps (:inputs caml_obj.mli) bs_stdlib_mini.cmi js.cmi js.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
 
 
   (rule
     (targets caml_oo.cmj)
     (deps (:inputs caml_oo.ml) caml_array.cmj caml_array_extern.cmj caml_exceptions.cmj caml_oo.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
 
 
   (rule
     (targets caml_oo.cmi)
     (deps (:inputs caml_oo.mli) bs_stdlib_mini.cmi js.cmi js.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
 
 
   (rule
     (targets caml_option.cmj)
     (deps (:inputs caml_option.ml) caml_option.cmi caml_undefined_extern.cmj js.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
 
 
   (rule
     (targets caml_option.cmi)
     (deps (:inputs caml_option.mli) bs_stdlib_mini.cmi caml_undefined_extern.cmj js.cmi js.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
 
 
   (rule
     (targets caml_parser.cmj)
     (deps (:inputs caml_parser.ml) caml_parser.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
 
 
   (rule
     (targets caml_parser.cmi)
     (deps (:inputs caml_parser.mli) bs_stdlib_mini.cmi js.cmi js.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
 
 
   (rule
     (targets caml_primitive.cmj)
     (deps (:inputs caml_primitive.ml) caml_primitive.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
 
 
   (rule
     (targets caml_primitive.cmi)
     (deps (:inputs caml_primitive.mli) bs_stdlib_mini.cmi js.cmi js.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
 
 
   (rule
     (targets caml_splice_call.cmj)
     (deps (:inputs caml_splice_call.ml) caml_splice_call.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
 
 
   (rule
     (targets caml_splice_call.cmi)
     (deps (:inputs caml_splice_call.mli) bs_stdlib_mini.cmi js.cmi js.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
 
 
   (rule
     (targets caml_string.cmj)
     (deps (:inputs caml_string.ml) caml_string.cmi caml_string_extern.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
 
 
   (rule
     (targets caml_string.cmi)
     (deps (:inputs caml_string.mli) bs_stdlib_mini.cmi js.cmi js.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
 
 
   (rule
     (targets caml_sys.cmj)
     (deps (:inputs caml_sys.ml) caml_array_extern.cmj caml_sys.cmi caml_undefined_extern.cmj js.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
 
 
   (rule
     (targets caml_sys.cmi)
     (deps (:inputs caml_sys.mli) bs_stdlib_mini.cmi js.cmi js.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
 
 
   (rule
     (targets caml_array_extern.cmi caml_array_extern.cmj)
     (deps (:inputs caml_array_extern.ml) bs_stdlib_mini.cmi js.cmi js.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
 
 
   (rule
     (targets caml_exceptions.cmi caml_exceptions.cmj)
     (deps (:inputs caml_exceptions.ml) bs_stdlib_mini.cmi js.cmi js.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
 
 
   (rule
     (targets caml_external_polyfill.cmi caml_external_polyfill.cmj)
     (deps (:inputs caml_external_polyfill.ml) bs_stdlib_mini.cmi js.cmi js.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
 
 
   (rule
     (targets caml_float_extern.cmi caml_float_extern.cmj)
     (deps (:inputs caml_float_extern.ml) bs_stdlib_mini.cmi js.cmi js.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
 
 
   (rule
     (targets caml_int32_extern.cmi caml_int32_extern.cmj)
     (deps (:inputs caml_int32_extern.ml) bs_stdlib_mini.cmi js.cmi js.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
 
 
   (rule
     (targets caml_int64_extern.cmi caml_int64_extern.cmj)
     (deps (:inputs caml_int64_extern.ml) bs_stdlib_mini.cmi js.cmi js.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
 
 
   (rule
     (targets caml_js_exceptions.cmi caml_js_exceptions.cmj)
     (deps (:inputs caml_js_exceptions.ml) bs_stdlib_mini.cmi caml_exceptions.cmj caml_option.cmj js.cmi js.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
 
 
   (rule
     (targets caml_nativeint_extern.cmi caml_nativeint_extern.cmj)
     (deps (:inputs caml_nativeint_extern.ml) bs_stdlib_mini.cmi js.cmi js.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
 
 
   (rule
     (targets caml_oo_curry.cmi caml_oo_curry.cmj)
     (deps (:inputs caml_oo_curry.ml) bs_stdlib_mini.cmi caml_oo.cmj curry.cmj js.cmi js.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
 
 
   (rule
     (targets caml_string_extern.cmi caml_string_extern.cmj)
     (deps (:inputs caml_string_extern.ml) bs_stdlib_mini.cmi js.cmi js.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
 
 
   (rule
     (targets caml_undefined_extern.cmi caml_undefined_extern.cmj)
     (deps (:inputs caml_undefined_extern.ml) bs_stdlib_mini.cmi js.cmi js.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
 
 
   (rule
     (targets curry.cmi curry.cmj)
     (deps (:inputs curry.ml) bs_stdlib_mini.cmi caml_array.cmj caml_array_extern.cmj js.cmi js.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -nopervasives  -unsafe -w +50 -warn-error A -open Bs_stdlib_mini -I . %{inputs})))
 
 
     (alias

--- a/jscomp/stdlib-412/dune.gen
+++ b/jscomp/stdlib-412/dune.gen
@@ -4,13 +4,13 @@
     (targets stdlib.cmi)
     (deps (:inputs stdlib.mli) (alias ./stdlib_modules/stdlib))
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -w -9-3-106 -warn-error A  -I ../runtime  -I ../others  -I ./stdlib_modules -nopervasives  -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -w -9-3-106 -warn-error A  -I ../runtime  -I ../others  -I ./stdlib_modules -nopervasives  -I . %{inputs})))
 
 
   (rule
     (targets stdlib.cmj)
     (deps (:inputs stdlib.ml) stdlib.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -w -9-3-106 -warn-error A  -I ../runtime  -I ../others  -I ./stdlib_modules -nopervasives  -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -w -9-3-106 -warn-error A  -I ../runtime  -I ../others  -I ./stdlib_modules -nopervasives  -I . %{inputs})))
 
     

--- a/jscomp/stdlib-412/stdlib_modules/dune.gen
+++ b/jscomp/stdlib-412/stdlib_modules/dune.gen
@@ -4,833 +4,833 @@
     (targets camlinternalFormatBasics.cmi)
     (deps (:inputs camlinternalFormatBasics.mli) (alias ../../others/others))
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -I . %{inputs})))
 
 
   (rule
     (targets camlinternalFormatBasics.cmj)
     (deps (:inputs camlinternalFormatBasics.ml) (alias ../../others/others) camlinternalFormatBasics.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -I . %{inputs})))
 
 
   (rule
     (targets camlinternalAtomic.cmi)
     (deps (:inputs camlinternalAtomic.mli) (alias ../../others/others))
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -I . %{inputs})))
 
 
   (rule
     (targets camlinternalAtomic.cmj)
     (deps (:inputs camlinternalAtomic.ml) (alias ../../others/others))
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -I . %{inputs})))
 
 
   (rule
     (targets stdlib__no_aliases.cmj stdlib__no_aliases.cmi)
     (deps (:inputs stdlib__no_aliases.ml) (alias ../../others/others) camlinternalFormatBasics.cmj camlinternalAtomic.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -I . %{inputs})))
 
 
   (rule
     (targets arg.cmj)
     (deps (:inputs arg.ml) (alias ../../others/others) arg.cmi array.cmj buffer.cmj list.cmj printf.cmj string.cmj sys.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets arg.cmi)
     (deps (:inputs arg.mli) (alias ../../others/others) stdlib__no_aliases.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets array.cmj)
     (deps (:inputs array.ml) (alias ../../others/others) array.cmi seq.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets array.cmi)
     (deps (:inputs array.mli) (alias ../../others/others) seq.cmi stdlib__no_aliases.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets arrayLabels.cmj)
     (deps (:inputs arrayLabels.ml) (alias ../../others/others) array.cmj arrayLabels.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -nolabels -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -nolabels -I . %{inputs})))
 
 
   (rule
     (targets arrayLabels.cmi)
     (deps (:inputs arrayLabels.mli) (alias ../../others/others) seq.cmi stdlib__no_aliases.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -nolabels -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -nolabels -I . %{inputs})))
 
 
   (rule
     (targets atomic.cmj)
     (deps (:inputs atomic.ml) (alias ../../others/others) atomic.cmi camlinternalAtomic.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets atomic.cmi)
     (deps (:inputs atomic.mli) (alias ../../others/others) stdlib__no_aliases.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets bool.cmj)
     (deps (:inputs bool.ml) (alias ../../others/others) bool.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets bool.cmi)
     (deps (:inputs bool.mli) (alias ../../others/others) stdlib__no_aliases.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets buffer.cmj)
     (deps (:inputs buffer.ml) (alias ../../others/others) buffer.cmi bytes.cmj char.cmj seq.cmj string.cmj sys.cmj uchar.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets buffer.cmi)
     (deps (:inputs buffer.mli) (alias ../../others/others) seq.cmi stdlib__no_aliases.cmj uchar.cmi)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets bytes.cmj)
     (deps (:inputs bytes.ml) (alias ../../others/others) bytes.cmi char.cmj seq.cmj sys.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets bytes.cmi)
     (deps (:inputs bytes.mli) (alias ../../others/others) seq.cmi stdlib__no_aliases.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets bytesLabels.cmj)
     (deps (:inputs bytesLabels.ml) (alias ../../others/others) bytes.cmj bytesLabels.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -nolabels -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -nolabels -I . %{inputs})))
 
 
   (rule
     (targets bytesLabels.cmi)
     (deps (:inputs bytesLabels.mli) (alias ../../others/others) seq.cmi stdlib__no_aliases.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -nolabels -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -nolabels -I . %{inputs})))
 
 
   (rule
     (targets callback.cmj)
     (deps (:inputs callback.ml) (alias ../../others/others) callback.cmi obj.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets callback.cmi)
     (deps (:inputs callback.mli) (alias ../../others/others) stdlib__no_aliases.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets camlinternalFormat.cmj)
     (deps (:inputs camlinternalFormat.ml) (alias ../../others/others) buffer.cmj bytes.cmj camlinternalFormat.cmi camlinternalFormatBasics.cmj char.cmj int.cmj string.cmj sys.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets camlinternalFormat.cmi)
     (deps (:inputs camlinternalFormat.mli) (alias ../../others/others) buffer.cmi camlinternalFormatBasics.cmi stdlib__no_aliases.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets camlinternalLazy.cmj)
     (deps (:inputs camlinternalLazy.ml) (alias ../../others/others) camlinternalLazy.cmi obj.cmj sys.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets camlinternalLazy.cmi)
     (deps (:inputs camlinternalLazy.mli) (alias ../../others/others) stdlib__no_aliases.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets camlinternalMod.cmj)
     (deps (:inputs camlinternalMod.ml) (alias ../../others/others) array.cmj camlinternalMod.cmi camlinternalOO.cmj obj.cmj sys.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets camlinternalMod.cmi)
     (deps (:inputs camlinternalMod.mli) (alias ../../others/others) obj.cmi stdlib__no_aliases.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets camlinternalOO.cmj)
     (deps (:inputs camlinternalOO.ml) (alias ../../others/others) array.cmj camlinternalOO.cmi char.cmj list.cmj map.cmj obj.cmj string.cmj sys.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets camlinternalOO.cmi)
     (deps (:inputs camlinternalOO.mli) (alias ../../others/others) obj.cmi stdlib__no_aliases.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets char.cmj)
     (deps (:inputs char.ml) (alias ../../others/others) char.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets char.cmi)
     (deps (:inputs char.mli) (alias ../../others/others) stdlib__no_aliases.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets complex.cmj)
     (deps (:inputs complex.ml) (alias ../../others/others) complex.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets complex.cmi)
     (deps (:inputs complex.mli) (alias ../../others/others) stdlib__no_aliases.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets digest.cmj)
     (deps (:inputs digest.ml) (alias ../../others/others) bytes.cmj char.cmj digest.cmi string.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets digest.cmi)
     (deps (:inputs digest.mli) (alias ../../others/others) stdlib__no_aliases.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets either.cmj)
     (deps (:inputs either.ml) (alias ../../others/others) either.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets either.cmi)
     (deps (:inputs either.mli) (alias ../../others/others) stdlib__no_aliases.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets ephemeron.cmj)
     (deps (:inputs ephemeron.ml) (alias ../../others/others) array.cmj ephemeron.cmi hashtbl.cmj lazy.cmj obj.cmj random.cmj seq.cmj sys.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets ephemeron.cmi)
     (deps (:inputs ephemeron.mli) (alias ../../others/others) hashtbl.cmi stdlib__no_aliases.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets filename.cmj)
     (deps (:inputs filename.ml) (alias ../../others/others) buffer.cmj filename.cmi lazy.cmj list.cmj printf.cmj random.cmj string.cmj sys.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets filename.cmi)
     (deps (:inputs filename.mli) (alias ../../others/others) stdlib__no_aliases.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets float.cmj)
     (deps (:inputs float.ml) (alias ../../others/others) array.cmj float.cmi list.cmj seq.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets float.cmi)
     (deps (:inputs float.mli) (alias ../../others/others) seq.cmi stdlib__no_aliases.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets format.cmj)
     (deps (:inputs format.ml) (alias ../../others/others) buffer.cmj camlinternalFormat.cmj camlinternalFormatBasics.cmj format.cmi int.cmj list.cmj queue.cmj seq.cmj stack.cmj string.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets format.cmi)
     (deps (:inputs format.mli) (alias ../../others/others) buffer.cmi seq.cmi stdlib__no_aliases.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets fun.cmj)
     (deps (:inputs fun.ml) (alias ../../others/others) fun.cmi printexc.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets fun.cmi)
     (deps (:inputs fun.mli) (alias ../../others/others) stdlib__no_aliases.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets gc.cmj)
     (deps (:inputs gc.ml) (alias ../../others/others) gc.cmi printexc.cmj printf.cmj string.cmj sys.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets gc.cmi)
     (deps (:inputs gc.mli) (alias ../../others/others) printexc.cmi stdlib__no_aliases.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets genlex.cmj)
     (deps (:inputs genlex.ml) (alias ../../others/others) bytes.cmj char.cmj genlex.cmi hashtbl.cmj list.cmj stream.cmj string.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets genlex.cmi)
     (deps (:inputs genlex.mli) (alias ../../others/others) stdlib__no_aliases.cmj stream.cmi)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets hashtbl.cmj)
     (deps (:inputs hashtbl.ml) (alias ../../others/others) array.cmj hashtbl.cmi lazy.cmj obj.cmj random.cmj seq.cmj string.cmj sys.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets hashtbl.cmi)
     (deps (:inputs hashtbl.mli) (alias ../../others/others) seq.cmi stdlib__no_aliases.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets int.cmj)
     (deps (:inputs int.ml) (alias ../../others/others) int.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets int.cmi)
     (deps (:inputs int.mli) (alias ../../others/others) stdlib__no_aliases.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets int32.cmj)
     (deps (:inputs int32.ml) (alias ../../others/others) int32.cmi sys.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets int32.cmi)
     (deps (:inputs int32.mli) (alias ../../others/others) stdlib__no_aliases.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets int64.cmj)
     (deps (:inputs int64.ml) (alias ../../others/others) int64.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets int64.cmi)
     (deps (:inputs int64.mli) (alias ../../others/others) stdlib__no_aliases.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets lazy.cmj)
     (deps (:inputs lazy.ml) (alias ../../others/others) camlinternalLazy.cmj lazy.cmi obj.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets lazy.cmi)
     (deps (:inputs lazy.mli) (alias ../../others/others) camlinternalLazy.cmi stdlib__no_aliases.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets lexing.cmj)
     (deps (:inputs lexing.ml) (alias ../../others/others) array.cmj bytes.cmj lexing.cmi string.cmj sys.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets lexing.cmi)
     (deps (:inputs lexing.mli) (alias ../../others/others) stdlib__no_aliases.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets list.cmj)
     (deps (:inputs list.ml) (alias ../../others/others) either.cmj list.cmi seq.cmj sys.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets list.cmi)
     (deps (:inputs list.mli) (alias ../../others/others) either.cmi seq.cmi stdlib__no_aliases.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets listLabels.cmj)
     (deps (:inputs listLabels.ml) (alias ../../others/others) list.cmj listLabels.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -nolabels -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -nolabels -I . %{inputs})))
 
 
   (rule
     (targets listLabels.cmi)
     (deps (:inputs listLabels.mli) (alias ../../others/others) either.cmi seq.cmi stdlib__no_aliases.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -nolabels -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -nolabels -I . %{inputs})))
 
 
   (rule
     (targets map.cmj)
     (deps (:inputs map.ml) (alias ../../others/others) map.cmi seq.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets map.cmi)
     (deps (:inputs map.mli) (alias ../../others/others) seq.cmi stdlib__no_aliases.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets marshal.cmj)
     (deps (:inputs marshal.ml) (alias ../../others/others) bytes.cmj marshal.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets marshal.cmi)
     (deps (:inputs marshal.mli) (alias ../../others/others) stdlib__no_aliases.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets moreLabels.cmj)
     (deps (:inputs moreLabels.ml) (alias ../../others/others) hashtbl.cmj map.cmj moreLabels.cmi set.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -nolabels -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -nolabels -I . %{inputs})))
 
 
   (rule
     (targets moreLabels.cmi)
     (deps (:inputs moreLabels.mli) (alias ../../others/others) hashtbl.cmi map.cmi seq.cmi set.cmi stdlib__no_aliases.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -nolabels -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -nolabels -I . %{inputs})))
 
 
   (rule
     (targets obj.cmj)
     (deps (:inputs obj.ml) (alias ../../others/others) int32.cmj marshal.cmj obj.cmi sys.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets obj.cmi)
     (deps (:inputs obj.mli) (alias ../../others/others) int32.cmi stdlib__no_aliases.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets oo.cmj)
     (deps (:inputs oo.ml) (alias ../../others/others) camlinternalOO.cmj oo.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets oo.cmi)
     (deps (:inputs oo.mli) (alias ../../others/others) camlinternalOO.cmi stdlib__no_aliases.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets option.cmj)
     (deps (:inputs option.ml) (alias ../../others/others) option.cmi seq.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets option.cmi)
     (deps (:inputs option.mli) (alias ../../others/others) seq.cmi stdlib__no_aliases.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets parsing.cmj)
     (deps (:inputs parsing.ml) (alias ../../others/others) array.cmj lexing.cmj obj.cmj parsing.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets parsing.cmi)
     (deps (:inputs parsing.mli) (alias ../../others/others) lexing.cmi obj.cmi stdlib__no_aliases.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets pervasives.cmi pervasives.cmj)
     (deps (:inputs pervasives.ml) (alias ../../others/others) camlinternalFormatBasics.cmj stdlib__no_aliases.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets printexc.cmj)
     (deps (:inputs printexc.ml) (alias ../../others/others) array.cmj atomic.cmj buffer.cmj obj.cmj printexc.cmi printf.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets printexc.cmi)
     (deps (:inputs printexc.mli) (alias ../../others/others) stdlib__no_aliases.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets printf.cmj)
     (deps (:inputs printf.ml) (alias ../../others/others) buffer.cmj camlinternalFormat.cmj camlinternalFormatBasics.cmj printf.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets printf.cmi)
     (deps (:inputs printf.mli) (alias ../../others/others) buffer.cmi stdlib__no_aliases.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets queue.cmj)
     (deps (:inputs queue.ml) (alias ../../others/others) queue.cmi seq.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets queue.cmi)
     (deps (:inputs queue.mli) (alias ../../others/others) seq.cmi stdlib__no_aliases.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets random.cmj)
     (deps (:inputs random.ml) (alias ../../others/others) array.cmj char.cmj digest.cmj int.cmj int32.cmj int64.cmj random.cmi string.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets random.cmi)
     (deps (:inputs random.mli) (alias ../../others/others) int32.cmi int64.cmi stdlib__no_aliases.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets result.cmj)
     (deps (:inputs result.ml) (alias ../../others/others) result.cmi seq.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets result.cmi)
     (deps (:inputs result.mli) (alias ../../others/others) seq.cmi stdlib__no_aliases.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets scanf.cmj)
     (deps (:inputs scanf.ml) (alias ../../others/others) buffer.cmj bytes.cmj camlinternalFormat.cmj camlinternalFormatBasics.cmj list.cmj printf.cmj scanf.cmi string.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets scanf.cmi)
     (deps (:inputs scanf.mli) (alias ../../others/others) stdlib__no_aliases.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets seq.cmj)
     (deps (:inputs seq.ml) (alias ../../others/others) seq.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets seq.cmi)
     (deps (:inputs seq.mli) (alias ../../others/others) stdlib__no_aliases.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets set.cmj)
     (deps (:inputs set.ml) (alias ../../others/others) list.cmj seq.cmj set.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets set.cmi)
     (deps (:inputs set.mli) (alias ../../others/others) seq.cmi stdlib__no_aliases.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets stack.cmj)
     (deps (:inputs stack.ml) (alias ../../others/others) list.cmj seq.cmj stack.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets stack.cmi)
     (deps (:inputs stack.mli) (alias ../../others/others) seq.cmi stdlib__no_aliases.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets stdLabels.cmj)
     (deps (:inputs stdLabels.ml) (alias ../../others/others) arrayLabels.cmj bytesLabels.cmj listLabels.cmj stdLabels.cmi stringLabels.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -nolabels -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -nolabels -I . %{inputs})))
 
 
   (rule
     (targets stdLabels.cmi)
     (deps (:inputs stdLabels.mli) (alias ../../others/others) arrayLabels.cmi bytesLabels.cmi listLabels.cmi stdlib__no_aliases.cmj stringLabels.cmi)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -nolabels -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -nolabels -I . %{inputs})))
 
 
   (rule
     (targets std_exit.cmi std_exit.cmj)
     (deps (:inputs std_exit.ml) (alias ../../others/others) stdlib__no_aliases.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets stream.cmj)
     (deps (:inputs stream.ml) (alias ../../others/others) bytes.cmj lazy.cmj list.cmj stream.cmi string.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets stream.cmi)
     (deps (:inputs stream.mli) (alias ../../others/others) stdlib__no_aliases.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets string.cmj)
     (deps (:inputs string.ml) (alias ../../others/others) bytes.cmj string.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets string.cmi)
     (deps (:inputs string.mli) (alias ../../others/others) seq.cmi stdlib__no_aliases.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets stringLabels.cmj)
     (deps (:inputs stringLabels.ml) (alias ../../others/others) string.cmj stringLabels.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -nolabels -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -nolabels -I . %{inputs})))
 
 
   (rule
     (targets stringLabels.cmi)
     (deps (:inputs stringLabels.mli) (alias ../../others/others) seq.cmi stdlib__no_aliases.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -nolabels -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -nolabels -I . %{inputs})))
 
 
   (rule
     (targets sys.cmj)
     (deps (:inputs sys.ml) (alias ../../others/others) sys.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets sys.cmi)
     (deps (:inputs sys.mli) (alias ../../others/others) stdlib__no_aliases.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets uchar.cmj)
     (deps (:inputs uchar.ml) (alias ../../others/others) char.cmj uchar.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets uchar.cmi)
     (deps (:inputs uchar.mli) (alias ../../others/others) stdlib__no_aliases.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets unit.cmj)
     (deps (:inputs unit.ml) (alias ../../others/others) unit.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets unit.cmi)
     (deps (:inputs unit.mli) (alias ../../others/others) stdlib__no_aliases.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets weak.cmj)
     (deps (:inputs weak.ml) (alias ../../others/others) array.cmj hashtbl.cmj obj.cmj sys.cmj weak.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
   (rule
     (targets weak.cmi)
     (deps (:inputs weak.mli) (alias ../../others/others) hashtbl.cmi stdlib__no_aliases.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime    -w -9-3-106 -warn-error A  -I ../../runtime  -I ../../others  -nopervasives -open Stdlib__no_aliases  -I . %{inputs})))
 
 
     (alias

--- a/jscomp/test/dune.gen
+++ b/jscomp/test/dune.gen
@@ -3,5108 +3,5129 @@
     (targets 406_primitive_test.cmi 406_primitive_test.cmj)
     (deps (:inputs 406_primitive_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets a.cmi a.cmj)
     (deps (:inputs a.ml) ../stdlib-412/stdlib test_order.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets a_filename_test.cmi a_filename_test.cmj)
     (deps (:inputs a_filename_test.ml) ../stdlib-412/stdlib ext_filename_test.cmj mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets a_list_test.cmi a_list_test.cmj)
     (deps (:inputs a_list_test.ml) ../stdlib-412/stdlib ext_list_test.cmj mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets a_recursive_type.cmj)
     (deps (:inputs a_recursive_type.ml) ../stdlib-412/stdlib a_recursive_type.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets a_recursive_type.cmi)
     (deps (:inputs a_recursive_type.mli) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets a_scope_bug.cmi a_scope_bug.cmj)
     (deps (:inputs a_scope_bug.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets a_string_test.cmi a_string_test.cmj)
     (deps (:inputs a_string_test.ml) ../stdlib-412/stdlib ext_string_test.cmj mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets abstract_type.cmj)
     (deps (:inputs abstract_type.ml) ../stdlib-412/stdlib abstract_type.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets abstract_type.cmi)
     (deps (:inputs abstract_type.mli) ../stdlib-412/stdlib mt.cmi)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets adt_optimize_test.cmi adt_optimize_test.cmj)
     (deps (:inputs adt_optimize_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets alias_test.cmj)
     (deps (:inputs alias_test.ml) ../stdlib-412/stdlib alias_test.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets alias_test.cmi)
     (deps (:inputs alias_test.mli) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets and_or_tailcall_test.cmi and_or_tailcall_test.cmj)
     (deps (:inputs and_or_tailcall_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets app_root_finder.cmi app_root_finder.cmj)
     (deps (:inputs app_root_finder.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets argv_test.cmi argv_test.cmj)
     (deps (:inputs argv_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets ari_regress_test.cmj)
     (deps (:inputs ari_regress_test.ml) ../stdlib-412/stdlib ari_regress_test.cmi mt.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets ari_regress_test.cmi)
     (deps (:inputs ari_regress_test.mli) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets arith_lexer.cmi arith_lexer.cmj)
     (deps (:inputs arith_lexer.ml) ../stdlib-412/stdlib arith_parser.cmj arith_syntax.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets arith_parser.cmi arith_parser.cmj)
     (deps (:inputs arith_parser.ml) ../stdlib-412/stdlib arith_syntax.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets arith_syntax.cmi arith_syntax.cmj)
     (deps (:inputs arith_syntax.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets arity.cmi arity.cmj)
     (deps (:inputs arity.re) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets arity_deopt.cmi arity_deopt.cmj)
     (deps (:inputs arity_deopt.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets arity_infer.cmi arity_infer.cmj)
     (deps (:inputs arity_infer.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets arity_ml.cmi arity_ml.cmj)
     (deps (:inputs arity_ml.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets array_data_util.cmi array_data_util.cmj)
     (deps (:inputs array_data_util.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets array_safe_get.cmi array_safe_get.cmj)
     (deps (:inputs array_safe_get.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets array_subtle_test.cmi array_subtle_test.cmj)
     (deps (:inputs array_subtle_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets array_test.cmj)
     (deps (:inputs array_test.ml) ../stdlib-412/stdlib array_test.cmi mt.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets array_test.cmi)
     (deps (:inputs array_test.mli) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets ast_abstract_test.cmi ast_abstract_test.cmj)
     (deps (:inputs ast_abstract_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets ast_js_mapper_poly_test.cmi ast_js_mapper_poly_test.cmj)
     (deps (:inputs ast_js_mapper_poly_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets ast_js_mapper_test.cmj)
     (deps (:inputs ast_js_mapper_test.ml) ../stdlib-412/stdlib ast_js_mapper_test.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets ast_js_mapper_test.cmi)
     (deps (:inputs ast_js_mapper_test.mli) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets ast_mapper_defensive_test.cmi ast_mapper_defensive_test.cmj)
     (deps (:inputs ast_mapper_defensive_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets ast_mapper_unused_warning_test.cmi ast_mapper_unused_warning_test.cmj)
     (deps (:inputs ast_mapper_unused_warning_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets async_ideas.cmi async_ideas.cmj)
     (deps (:inputs async_ideas.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets attr_test.cmi attr_test.cmj)
     (deps (:inputs attr_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets b.cmi b.cmj)
     (deps (:inputs b.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets bal_set_mini.cmi bal_set_mini.cmj)
     (deps (:inputs bal_set_mini.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets bang_primitive.cmi bang_primitive.cmj)
     (deps (:inputs bang_primitive.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets basic_module_test.cmj)
     (deps (:inputs basic_module_test.ml) ../stdlib-412/stdlib basic_module_test.cmi mt.cmj mt_global.cmj offset.cmj pr6726.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets basic_module_test.cmi)
     (deps (:inputs basic_module_test.mli) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets bb.cmi bb.cmj)
     (deps (:inputs bb.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets bdd.cmi bdd.cmj)
     (deps (:inputs bdd.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets belt_internal_test.cmi belt_internal_test.cmj)
     (deps (:inputs belt_internal_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets belt_result_alias_test.cmi belt_result_alias_test.cmj)
     (deps (:inputs belt_result_alias_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets bench.cmi bench.cmj)
     (deps (:inputs bench.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets big_enum.cmi big_enum.cmj)
     (deps (:inputs big_enum.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets big_polyvar_test.cmi big_polyvar_test.cmj)
     (deps (:inputs big_polyvar_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets block_alias_test.cmi block_alias_test.cmj)
     (deps (:inputs block_alias_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets boolean_test.cmi boolean_test.cmj)
     (deps (:inputs boolean_test.ml) ../stdlib-412/stdlib mt.cmj test_bool_equal.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets bs_MapInt_test.cmi bs_MapInt_test.cmj)
     (deps (:inputs bs_MapInt_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets bs_abstract_test.cmj)
     (deps (:inputs bs_abstract_test.ml) ../stdlib-412/stdlib bs_abstract_test.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets bs_abstract_test.cmi)
     (deps (:inputs bs_abstract_test.mli) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets bs_array_test.cmi bs_array_test.cmj)
     (deps (:inputs bs_array_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets bs_auto_uncurry.cmi bs_auto_uncurry.cmj)
     (deps (:inputs bs_auto_uncurry.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets bs_auto_uncurry_test.cmi bs_auto_uncurry_test.cmj)
     (deps (:inputs bs_auto_uncurry_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets bs_float_test.cmi bs_float_test.cmj)
     (deps (:inputs bs_float_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets bs_hashmap_test.cmi bs_hashmap_test.cmj)
     (deps (:inputs bs_hashmap_test.ml) ../stdlib-412/stdlib array_data_util.cmj mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets bs_hashset_int_test.cmi bs_hashset_int_test.cmj)
     (deps (:inputs bs_hashset_int_test.ml) ../stdlib-412/stdlib array_data_util.cmj mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets bs_hashtbl_string_test.cmi bs_hashtbl_string_test.cmj)
     (deps (:inputs bs_hashtbl_string_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets bs_ignore_effect.cmi bs_ignore_effect.cmj)
     (deps (:inputs bs_ignore_effect.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets bs_ignore_test.cmi bs_ignore_test.cmj)
     (deps (:inputs bs_ignore_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets bs_int_test.cmi bs_int_test.cmj)
     (deps (:inputs bs_int_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets bs_list_test.cmi bs_list_test.cmj)
     (deps (:inputs bs_list_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets bs_map_set_dict_test.cmi bs_map_set_dict_test.cmj)
     (deps (:inputs bs_map_set_dict_test.ml) ../stdlib-412/stdlib array_data_util.cmj mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets bs_map_test.cmi bs_map_test.cmj)
     (deps (:inputs bs_map_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets bs_min_max_test.cmi bs_min_max_test.cmj)
     (deps (:inputs bs_min_max_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets bs_mutable_set_test.cmi bs_mutable_set_test.cmj)
     (deps (:inputs bs_mutable_set_test.ml) ../stdlib-412/stdlib array_data_util.cmj mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets bs_node_string_buffer_test.cmi bs_node_string_buffer_test.cmj)
     (deps (:inputs bs_node_string_buffer_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets bs_poly_map_test.cmi bs_poly_map_test.cmj)
     (deps (:inputs bs_poly_map_test.ml) ../stdlib-412/stdlib array_data_util.cmj mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets bs_poly_mutable_map_test.cmi bs_poly_mutable_map_test.cmj)
     (deps (:inputs bs_poly_mutable_map_test.ml) ../stdlib-412/stdlib array_data_util.cmj mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets bs_poly_mutable_set_test.cmi bs_poly_mutable_set_test.cmj)
     (deps (:inputs bs_poly_mutable_set_test.ml) ../stdlib-412/stdlib array_data_util.cmj mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets bs_poly_set_test.cmi bs_poly_set_test.cmj)
     (deps (:inputs bs_poly_set_test.ml) ../stdlib-412/stdlib array_data_util.cmj mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets bs_qualified.cmi bs_qualified.cmj)
     (deps (:inputs bs_qualified.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets bs_queue_test.cmi bs_queue_test.cmj)
     (deps (:inputs bs_queue_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets bs_rbset_int_bench.cmi bs_rbset_int_bench.cmj)
     (deps (:inputs bs_rbset_int_bench.ml) ../stdlib-412/stdlib rbset.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets bs_rest_test.cmi bs_rest_test.cmj)
     (deps (:inputs bs_rest_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets bs_set_bench.cmi bs_set_bench.cmj)
     (deps (:inputs bs_set_bench.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets bs_set_int_test.cmi bs_set_int_test.cmj)
     (deps (:inputs bs_set_int_test.ml) ../stdlib-412/stdlib array_data_util.cmj mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets bs_sort_test.cmi bs_sort_test.cmj)
     (deps (:inputs bs_sort_test.ml) ../stdlib-412/stdlib array_data_util.cmj mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets bs_splice_partial.cmi bs_splice_partial.cmj)
     (deps (:inputs bs_splice_partial.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets bs_stack_test.cmi bs_stack_test.cmj)
     (deps (:inputs bs_stack_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets bs_string_test.cmi bs_string_test.cmj)
     (deps (:inputs bs_string_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets bs_unwrap_test.cmi bs_unwrap_test.cmj)
     (deps (:inputs bs_unwrap_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets buffer_test.cmi buffer_test.cmj)
     (deps (:inputs buffer_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets bytes_split_gpr_743_test.cmi bytes_split_gpr_743_test.cmj)
     (deps (:inputs bytes_split_gpr_743_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets caml_compare_test.cmi caml_compare_test.cmj)
     (deps (:inputs caml_compare_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets caml_format_test.cmi caml_format_test.cmj)
     (deps (:inputs caml_format_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets caml_sys_poly_fill_test.cmi caml_sys_poly_fill_test.cmj)
     (deps (:inputs caml_sys_poly_fill_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets chain_code_test.cmi chain_code_test.cmj)
     (deps (:inputs chain_code_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets chn_test.cmi chn_test.cmj)
     (deps (:inputs chn_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets class3_test.cmi class3_test.cmj)
     (deps (:inputs class3_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets class4_test.cmi class4_test.cmj)
     (deps (:inputs class4_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets class5_test.cmi class5_test.cmj)
     (deps (:inputs class5_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets class6_test.cmi class6_test.cmj)
     (deps (:inputs class6_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets class7_test.cmi class7_test.cmj)
     (deps (:inputs class7_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets class8_test.cmi class8_test.cmj)
     (deps (:inputs class8_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets class_fib_open_recursion_test.cmi class_fib_open_recursion_test.cmj)
     (deps (:inputs class_fib_open_recursion_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets class_repr.cmi class_repr.cmj)
     (deps (:inputs class_repr.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets class_setter_getter.cmj)
     (deps (:inputs class_setter_getter.ml) ../stdlib-412/stdlib class_setter_getter.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets class_setter_getter.cmi)
     (deps (:inputs class_setter_getter.mli) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets class_test.cmi class_test.cmj)
     (deps (:inputs class_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets class_type_ffi_test.cmi class_type_ffi_test.cmj)
     (deps (:inputs class_type_ffi_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets compare_test.cmi compare_test.cmj)
     (deps (:inputs compare_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets complete_parmatch_test.cmi complete_parmatch_test.cmj)
     (deps (:inputs complete_parmatch_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets complex_if_test.cmi complex_if_test.cmj)
     (deps (:inputs complex_if_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets complex_test.cmi complex_test.cmj)
     (deps (:inputs complex_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets complex_while_loop.cmi complex_while_loop.cmj)
     (deps (:inputs complex_while_loop.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets condition_compilation_test.cmi condition_compilation_test.cmj)
     (deps (:inputs condition_compilation_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets config1_test.cmi config1_test.cmj)
     (deps (:inputs config1_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets config2_test.cmj)
     (deps (:inputs config2_test.ml) ../stdlib-412/stdlib config2_test.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets config2_test.cmi)
     (deps (:inputs config2_test.mli) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets console_log_test.cmi console_log_test.cmj)
     (deps (:inputs console_log_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets const_block_test.cmj)
     (deps (:inputs const_block_test.ml) ../stdlib-412/stdlib const_block_test.cmi mt.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets const_block_test.cmi)
     (deps (:inputs const_block_test.mli) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets const_defs.cmi const_defs.cmj)
     (deps (:inputs const_defs.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets const_defs_test.cmi const_defs_test.cmj)
     (deps (:inputs const_defs_test.ml) ../stdlib-412/stdlib const_defs.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets const_test.cmi const_test.cmj)
     (deps (:inputs const_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets cont_int_fold_test.cmi cont_int_fold_test.cmj)
     (deps (:inputs cont_int_fold_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets cps_test.cmi cps_test.cmj)
     (deps (:inputs cps_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets cross_module_inline_test.cmi cross_module_inline_test.cmj)
     (deps (:inputs cross_module_inline_test.ml) ../stdlib-412/stdlib test_char.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets custom_error_test.cmi custom_error_test.cmj)
     (deps (:inputs custom_error_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets debug_keep_test.cmi debug_keep_test.cmj)
     (deps (:inputs debug_keep_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets debug_mode_value.cmi debug_mode_value.cmj)
     (deps (:inputs debug_mode_value.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets debug_tmp.cmi debug_tmp.cmj)
     (deps (:inputs debug_tmp.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets debugger_test.cmi debugger_test.cmj)
     (deps (:inputs debugger_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets default_export_test.cmi default_export_test.cmj)
     (deps (:inputs default_export_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets defunctor_make_test.cmi defunctor_make_test.cmj)
     (deps (:inputs defunctor_make_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets demo.cmi demo.cmj)
     (deps (:inputs demo.ml) ../stdlib-412/stdlib demo_binding.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets demo_binding.cmi demo_binding.cmj)
     (deps (:inputs demo_binding.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets demo_int_map.cmj)
     (deps (:inputs demo_int_map.ml) ../stdlib-412/stdlib demo_int_map.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets demo_int_map.cmi)
     (deps (:inputs demo_int_map.mli) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets demo_page.cmi demo_page.cmj)
     (deps (:inputs demo_page.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets demo_pipe.cmi demo_pipe.cmj)
     (deps (:inputs demo_pipe.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets derive_dyntype.cmi derive_dyntype.cmj)
     (deps (:inputs derive_dyntype.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets derive_projector_test.cmj)
     (deps (:inputs derive_projector_test.ml) ../stdlib-412/stdlib derive_projector_test.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets derive_projector_test.cmi)
     (deps (:inputs derive_projector_test.mli) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets derive_type_test.cmi derive_type_test.cmj)
     (deps (:inputs derive_type_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets digest_test.cmi digest_test.cmj)
     (deps (:inputs digest_test.ml) ../stdlib-412/stdlib ext_array_test.cmj mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets div_by_zero_test.cmi div_by_zero_test.cmj)
     (deps (:inputs div_by_zero_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets dollar_escape_test.cmi dollar_escape_test.cmj)
     (deps (:inputs dollar_escape_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets earger_curry_test.cmi earger_curry_test.cmj)
     (deps (:inputs earger_curry_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets effect.cmi effect.cmj)
     (deps (:inputs effect.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets empty_obj.cmi empty_obj.cmj)
     (deps (:inputs empty_obj.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets epsilon_test.cmi epsilon_test.cmj)
     (deps (:inputs epsilon_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets equal_box_test.cmi equal_box_test.cmj)
     (deps (:inputs equal_box_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets equal_exception_test.cmi equal_exception_test.cmj)
     (deps (:inputs equal_exception_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets equal_test.cmi equal_test.cmj)
     (deps (:inputs equal_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets es6_export.cmi es6_export.cmj)
     (deps (:inputs es6_export.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets es6_import.cmi es6_import.cmj)
     (deps (:inputs es6_import.ml) ../stdlib-412/stdlib es6_export.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets es6_module_test.cmi es6_module_test.cmj)
     (deps (:inputs es6_module_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets escape_esmodule.cmi escape_esmodule.cmj)
     (deps (:inputs escape_esmodule.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets esmodule_ref.cmi esmodule_ref.cmj)
     (deps (:inputs esmodule_ref.ml) ../stdlib-412/stdlib escape_esmodule.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets event_ffi.cmi event_ffi.cmj)
     (deps (:inputs event_ffi.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets exception_alias.cmi exception_alias.cmj)
     (deps (:inputs exception_alias.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets exception_def.cmi exception_def.cmj)
     (deps (:inputs exception_def.ml) ../stdlib-412/stdlib mt.cmj test_other_exn.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets exception_raise_test.cmi exception_raise_test.cmj)
     (deps (:inputs exception_raise_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets exception_rebind_test.cmi exception_rebind_test.cmj)
     (deps (:inputs exception_rebind_test.ml) ../stdlib-412/stdlib exception_def.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets exception_rebound_err_test.cmi exception_rebound_err_test.cmj)
     (deps (:inputs exception_rebound_err_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets exception_repr_test.cmi exception_repr_test.cmj)
     (deps (:inputs exception_repr_test.ml) ../stdlib-412/stdlib exception_def.cmj mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets exception_value_test.cmi exception_value_test.cmj)
     (deps (:inputs exception_value_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets exn_error_pattern.cmi exn_error_pattern.cmj)
     (deps (:inputs exn_error_pattern.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets export_keyword.cmi export_keyword.cmj)
     (deps (:inputs export_keyword.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets ext_array_test.cmi ext_array_test.cmj)
     (deps (:inputs ext_array_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets ext_bytes_test.cmi ext_bytes_test.cmj)
     (deps (:inputs ext_bytes_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets ext_filename_test.cmi ext_filename_test.cmj)
     (deps (:inputs ext_filename_test.ml) ../stdlib-412/stdlib ext_pervasives_test.cmj ext_string_test.cmj test_literals.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets ext_list_test.cmi ext_list_test.cmj)
     (deps (:inputs ext_list_test.ml) ../stdlib-412/stdlib ext_string_test.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets ext_log_test.cmi ext_log_test.cmj)
     (deps (:inputs ext_log_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets ext_pervasives_test.cmj)
     (deps (:inputs ext_pervasives_test.ml) ../stdlib-412/stdlib ext_pervasives_test.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets ext_pervasives_test.cmi)
     (deps (:inputs ext_pervasives_test.mli) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets ext_string_test.cmi ext_string_test.cmj)
     (deps (:inputs ext_string_test.ml) ../stdlib-412/stdlib ext_bytes_test.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets ext_sys_test.cmj)
     (deps (:inputs ext_sys_test.ml) ../stdlib-412/stdlib ext_sys_test.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets ext_sys_test.cmi)
     (deps (:inputs ext_sys_test.mli) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets extensible_variant_test.cmi extensible_variant_test.cmj)
     (deps (:inputs extensible_variant_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets external_polyfill_test.cmi external_polyfill_test.cmj)
     (deps (:inputs external_polyfill_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets external_ppx.cmi external_ppx.cmj)
     (deps (:inputs external_ppx.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets fail_comp.cmi fail_comp.cmj)
     (deps (:inputs fail_comp.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets ffi_arity_test.cmi ffi_arity_test.cmj)
     (deps (:inputs ffi_arity_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets ffi_array_test.cmi ffi_array_test.cmj)
     (deps (:inputs ffi_array_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets ffi_js_test.cmi ffi_js_test.cmj)
     (deps (:inputs ffi_js_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets ffi_splice_test.cmi ffi_splice_test.cmj)
     (deps (:inputs ffi_splice_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets ffi_test.cmi ffi_test.cmj)
     (deps (:inputs ffi_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets fib.cmi fib.cmj)
     (deps (:inputs fib.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets flattern_order_test.cmi flattern_order_test.cmj)
     (deps (:inputs flattern_order_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets flexible_array_test.cmi flexible_array_test.cmj)
     (deps (:inputs flexible_array_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets float_array.cmi float_array.cmj)
     (deps (:inputs float_array.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets float_of_bits_test.cmi float_of_bits_test.cmj)
     (deps (:inputs float_of_bits_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets float_record.cmj)
     (deps (:inputs float_record.ml) ../stdlib-412/stdlib float_record.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets float_record.cmi)
     (deps (:inputs float_record.mli) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets float_test.cmi float_test.cmj)
     (deps (:inputs float_test.ml) ../stdlib-412/stdlib mt.cmj mt_global.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets floatarray_test.cmi floatarray_test.cmj)
     (deps (:inputs floatarray_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets flow_parser_reg_test.cmj)
     (deps (:inputs flow_parser_reg_test.ml) ../stdlib-412/stdlib flow_parser_reg_test.cmi mt.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets flow_parser_reg_test.cmi)
     (deps (:inputs flow_parser_reg_test.mli) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets for_loop_test.cmi for_loop_test.cmj)
     (deps (:inputs for_loop_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets for_side_effect_test.cmi for_side_effect_test.cmj)
     (deps (:inputs for_side_effect_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets format_regression.cmi format_regression.cmj)
     (deps (:inputs format_regression.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets format_test.cmi format_test.cmj)
     (deps (:inputs format_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets fs_test.cmi fs_test.cmj)
     (deps (:inputs fs_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets fun_pattern_match.cmi fun_pattern_match.cmj)
     (deps (:inputs fun_pattern_match.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets functor_app_test.cmi functor_app_test.cmj)
     (deps (:inputs functor_app_test.ml) ../stdlib-412/stdlib functor_def.cmj functor_inst.cmj mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets functor_def.cmi functor_def.cmj)
     (deps (:inputs functor_def.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets functor_ffi.cmi functor_ffi.cmj)
     (deps (:inputs functor_ffi.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets functor_inst.cmi functor_inst.cmj)
     (deps (:inputs functor_inst.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets functors.cmi functors.cmj)
     (deps (:inputs functors.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gbk.cmi gbk.cmj)
     (deps (:inputs gbk.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets genlex_test.cmi genlex_test.cmj)
     (deps (:inputs genlex_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gentTypeReTest.cmi gentTypeReTest.cmj)
     (deps (:inputs gentTypeReTest.re) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets global_exception_regression_test.cmi global_exception_regression_test.cmj)
     (deps (:inputs global_exception_regression_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets global_mangles.cmi global_mangles.cmj)
     (deps (:inputs global_mangles.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets global_module_alias_test.cmi global_module_alias_test.cmj)
     (deps (:inputs global_module_alias_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets google_closure_test.cmi google_closure_test.cmj)
     (deps (:inputs google_closure_test.ml) ../stdlib-412/stdlib mt.cmj test_google_closure.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr496_test.cmi gpr496_test.cmj)
     (deps (:inputs gpr496_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_1063_test.cmi gpr_1063_test.cmj)
     (deps (:inputs gpr_1063_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_1072.cmi gpr_1072.cmj)
     (deps (:inputs gpr_1072.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_1072_reg.cmi gpr_1072_reg.cmj)
     (deps (:inputs gpr_1072_reg.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_1150.cmi gpr_1150.cmj)
     (deps (:inputs gpr_1150.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_1154_test.cmi gpr_1154_test.cmj)
     (deps (:inputs gpr_1154_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_1170.cmi gpr_1170.cmj)
     (deps (:inputs gpr_1170.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_1240_missing_unbox.cmi gpr_1240_missing_unbox.cmj)
     (deps (:inputs gpr_1240_missing_unbox.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_1245_test.cmi gpr_1245_test.cmj)
     (deps (:inputs gpr_1245_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_1268.cmi gpr_1268.cmj)
     (deps (:inputs gpr_1268.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_1285_test.cmi gpr_1285_test.cmj)
     (deps (:inputs gpr_1285_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_1409_test.cmi gpr_1409_test.cmj)
     (deps (:inputs gpr_1409_test.ml) ../stdlib-412/stdlib mt.cmj string_set.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_1423_app_test.cmi gpr_1423_app_test.cmj)
     (deps (:inputs gpr_1423_app_test.ml) ../stdlib-412/stdlib gpr_1423_nav.cmj mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_1423_nav.cmi gpr_1423_nav.cmj)
     (deps (:inputs gpr_1423_nav.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_1438.cmi gpr_1438.cmj)
     (deps (:inputs gpr_1438.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_1481.cmi gpr_1481.cmj)
     (deps (:inputs gpr_1481.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_1484.cmi gpr_1484.cmj)
     (deps (:inputs gpr_1484.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_1501_test.cmi gpr_1501_test.cmj)
     (deps (:inputs gpr_1501_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_1503_test.cmi gpr_1503_test.cmj)
     (deps (:inputs gpr_1503_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_1539_test.cmi gpr_1539_test.cmj)
     (deps (:inputs gpr_1539_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_1600_test.cmi gpr_1600_test.cmj)
     (deps (:inputs gpr_1600_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_1658_test.cmi gpr_1658_test.cmj)
     (deps (:inputs gpr_1658_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_1667_test.cmi gpr_1667_test.cmj)
     (deps (:inputs gpr_1667_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_1692_test.cmi gpr_1692_test.cmj)
     (deps (:inputs gpr_1692_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_1698_test.cmi gpr_1698_test.cmj)
     (deps (:inputs gpr_1698_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_1701_test.cmi gpr_1701_test.cmj)
     (deps (:inputs gpr_1701_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_1716_test.cmi gpr_1716_test.cmj)
     (deps (:inputs gpr_1716_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_1717_test.cmi gpr_1717_test.cmj)
     (deps (:inputs gpr_1717_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_1728_test.cmi gpr_1728_test.cmj)
     (deps (:inputs gpr_1728_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_1749_test.cmi gpr_1749_test.cmj)
     (deps (:inputs gpr_1749_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_1759_test.cmi gpr_1759_test.cmj)
     (deps (:inputs gpr_1759_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_1760_test.cmi gpr_1760_test.cmj)
     (deps (:inputs gpr_1760_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_1762_test.cmi gpr_1762_test.cmj)
     (deps (:inputs gpr_1762_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_1817_test.cmi gpr_1817_test.cmj)
     (deps (:inputs gpr_1817_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_1822_test.cmi gpr_1822_test.cmj)
     (deps (:inputs gpr_1822_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_1891_test.cmi gpr_1891_test.cmj)
     (deps (:inputs gpr_1891_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_1943_test.cmi gpr_1943_test.cmj)
     (deps (:inputs gpr_1943_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_1946_test.cmi gpr_1946_test.cmj)
     (deps (:inputs gpr_1946_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_2250_test.cmi gpr_2250_test.cmj)
     (deps (:inputs gpr_2250_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_2316_test.cmi gpr_2316_test.cmj)
     (deps (:inputs gpr_2316_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_2352_test.cmi gpr_2352_test.cmj)
     (deps (:inputs gpr_2352_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_2413_test.cmi gpr_2413_test.cmj)
     (deps (:inputs gpr_2413_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_2474.cmi gpr_2474.cmj)
     (deps (:inputs gpr_2474.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_2487.cmi gpr_2487.cmj)
     (deps (:inputs gpr_2487.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_2503_test.cmi gpr_2503_test.cmj)
     (deps (:inputs gpr_2503_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_2608_test.cmi gpr_2608_test.cmj)
     (deps (:inputs gpr_2608_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_2614_test.cmi gpr_2614_test.cmj)
     (deps (:inputs gpr_2614_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_2633_test.cmi gpr_2633_test.cmj)
     (deps (:inputs gpr_2633_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_2642_test.cmi gpr_2642_test.cmj)
     (deps (:inputs gpr_2642_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_2652_test.cmi gpr_2652_test.cmj)
     (deps (:inputs gpr_2652_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_2682_test.cmi gpr_2682_test.cmj)
     (deps (:inputs gpr_2682_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_2700_test.cmi gpr_2700_test.cmj)
     (deps (:inputs gpr_2700_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_2731_test.cmi gpr_2731_test.cmj)
     (deps (:inputs gpr_2731_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_2789_test.cmi gpr_2789_test.cmj)
     (deps (:inputs gpr_2789_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_2863_test.cmi gpr_2863_test.cmj)
     (deps (:inputs gpr_2863_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_2931_test.cmi gpr_2931_test.cmj)
     (deps (:inputs gpr_2931_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_3142_test.cmi gpr_3142_test.cmj)
     (deps (:inputs gpr_3142_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_3154_test.cmi gpr_3154_test.cmj)
     (deps (:inputs gpr_3154_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_3209_test.cmi gpr_3209_test.cmj)
     (deps (:inputs gpr_3209_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_3492_test.cmi gpr_3492_test.cmj)
     (deps (:inputs gpr_3492_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_3502_test.cmi gpr_3502_test.cmj)
     (deps (:inputs gpr_3502_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_3519_jsx_test.cmi gpr_3519_jsx_test.cmj)
     (deps (:inputs gpr_3519_jsx_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_3519_test.cmi gpr_3519_test.cmj)
     (deps (:inputs gpr_3519_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_3536_test.cmi gpr_3536_test.cmj)
     (deps (:inputs gpr_3536_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_3546_test.cmi gpr_3546_test.cmj)
     (deps (:inputs gpr_3546_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_3548_test.cmi gpr_3548_test.cmj)
     (deps (:inputs gpr_3548_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_3549_test.cmi gpr_3549_test.cmj)
     (deps (:inputs gpr_3549_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_3566_drive_test.cmi gpr_3566_drive_test.cmj)
     (deps (:inputs gpr_3566_drive_test.ml) ../stdlib-412/stdlib gpr_3566_test.cmj mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_3566_test.cmi gpr_3566_test.cmj)
     (deps (:inputs gpr_3566_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_3595_test.cmi gpr_3595_test.cmj)
     (deps (:inputs gpr_3595_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_3609_test.cmi gpr_3609_test.cmj)
     (deps (:inputs gpr_3609_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_3697_test.cmi gpr_3697_test.cmj)
     (deps (:inputs gpr_3697_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_373_test.cmi gpr_373_test.cmj)
     (deps (:inputs gpr_373_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_3770_test.cmi gpr_3770_test.cmj)
     (deps (:inputs gpr_3770_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_3852_alias.cmi gpr_3852_alias.cmj)
     (deps (:inputs gpr_3852_alias.ml) ../stdlib-412/stdlib gpr_3852_effect.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_3852_alias_reify.cmj)
     (deps (:inputs gpr_3852_alias_reify.ml) ../stdlib-412/stdlib gpr_3852_alias_reify.cmi gpr_3852_effect.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_3852_alias_reify.cmi)
     (deps (:inputs gpr_3852_alias_reify.mli) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_3852_effect.cmi gpr_3852_effect.cmj)
     (deps (:inputs gpr_3852_effect.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_3865.cmi gpr_3865.cmj)
     (deps (:inputs gpr_3865.re) ../stdlib-412/stdlib gpr_3865_bar.cmj gpr_3865_foo.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_3865_bar.cmi gpr_3865_bar.cmj)
     (deps (:inputs gpr_3865_bar.re) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_3865_foo.cmi gpr_3865_foo.cmj)
     (deps (:inputs gpr_3865_foo.re) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_3875_test.cmi gpr_3875_test.cmj)
     (deps (:inputs gpr_3875_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_3877_test.cmi gpr_3877_test.cmj)
     (deps (:inputs gpr_3877_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_3895_test.cmi gpr_3895_test.cmj)
     (deps (:inputs gpr_3895_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_3897_test.cmi gpr_3897_test.cmj)
     (deps (:inputs gpr_3897_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_3931_test.cmi gpr_3931_test.cmj)
     (deps (:inputs gpr_3931_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_3980_test.cmi gpr_3980_test.cmj)
     (deps (:inputs gpr_3980_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_4025_test.cmi gpr_4025_test.cmj)
     (deps (:inputs gpr_4025_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_405_test.cmj)
     (deps (:inputs gpr_405_test.ml) ../stdlib-412/stdlib gpr_405_test.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_405_test.cmi)
     (deps (:inputs gpr_405_test.mli) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_4069_test.cmi gpr_4069_test.cmj)
     (deps (:inputs gpr_4069_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_4265_test.cmi gpr_4265_test.cmj)
     (deps (:inputs gpr_4265_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_4274_test.cmi gpr_4274_test.cmj)
     (deps (:inputs gpr_4274_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_4280_test.cmi gpr_4280_test.cmj)
     (deps (:inputs gpr_4280_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_4407_test.cmi gpr_4407_test.cmj)
     (deps (:inputs gpr_4407_test.ml) ../stdlib-412/stdlib debug_mode_value.cmj mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_441.cmi gpr_441.cmj)
     (deps (:inputs gpr_441.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_4442_test.cmi gpr_4442_test.cmj)
     (deps (:inputs gpr_4442_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_4491_test.cmi gpr_4491_test.cmj)
     (deps (:inputs gpr_4491_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_4494_test.cmi gpr_4494_test.cmj)
     (deps (:inputs gpr_4494_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_4519_test.cmi gpr_4519_test.cmj)
     (deps (:inputs gpr_4519_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_459_test.cmi gpr_459_test.cmj)
     (deps (:inputs gpr_459_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_4639_test.cmi gpr_4639_test.cmj)
     (deps (:inputs gpr_4639_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+
+
+  (rule
+    (targets gpr_4900_test.cmi gpr_4900_test.cmj)
+    (deps (:inputs gpr_4900_test.ml) ../stdlib-412/stdlib mt.cmj)
+    (action
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_4924_test.cmi gpr_4924_test.cmj)
-    (deps (:inputs gpr_4924_test.ml) ../stdlib-412/stdlib)
+    (deps (:inputs gpr_4924_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_4931.cmi gpr_4931.cmj)
     (deps (:inputs gpr_4931.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_627_test.cmi gpr_627_test.cmj)
     (deps (:inputs gpr_627_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_658.cmi gpr_658.cmj)
     (deps (:inputs gpr_658.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_858_test.cmi gpr_858_test.cmj)
     (deps (:inputs gpr_858_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_858_unit2_test.cmi gpr_858_unit2_test.cmj)
     (deps (:inputs gpr_858_unit2_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_904_test.cmi gpr_904_test.cmj)
     (deps (:inputs gpr_904_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_974_test.cmi gpr_974_test.cmj)
     (deps (:inputs gpr_974_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_977_test.cmi gpr_977_test.cmj)
     (deps (:inputs gpr_977_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gpr_return_type_unused_attribute.cmi gpr_return_type_unused_attribute.cmj)
     (deps (:inputs gpr_return_type_unused_attribute.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets gray_code_test.cmi gray_code_test.cmj)
     (deps (:inputs gray_code_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets guide_for_ext.cmi guide_for_ext.cmj)
     (deps (:inputs guide_for_ext.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets hamming_test.cmi hamming_test.cmj)
     (deps (:inputs hamming_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets hash_collision_test.cmi hash_collision_test.cmj)
     (deps (:inputs hash_collision_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+
+
+  (rule
+    (targets hash_sugar_desugar.cmj)
+    (deps (:inputs hash_sugar_desugar.ml) ../stdlib-412/stdlib hash_sugar_desugar.cmi)
+    (action
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+
+
+  (rule
+    (targets hash_sugar_desugar.cmi)
+    (deps (:inputs hash_sugar_desugar.mli) ../stdlib-412/stdlib)
+    (action
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets hash_test.cmi hash_test.cmj)
     (deps (:inputs hash_test.ml) ../stdlib-412/stdlib mt.cmj mt_global.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets hashtbl_test.cmi hashtbl_test.cmj)
     (deps (:inputs hashtbl_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets hello.foo.cmi hello.foo.cmj)
     (deps (:inputs hello.foo.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets http_types.cmi http_types.cmj)
     (deps (:inputs http_types.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets if_used_test.cmi if_used_test.cmj)
     (deps (:inputs if_used_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets ignore_test.cmi ignore_test.cmj)
     (deps (:inputs ignore_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets imm_map_bench.cmi imm_map_bench.cmj)
     (deps (:inputs imm_map_bench.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets include_side_effect.cmi include_side_effect.cmj)
     (deps (:inputs include_side_effect.ml) ../stdlib-412/stdlib side_effect.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets include_side_effect_free.cmi include_side_effect_free.cmj)
     (deps (:inputs include_side_effect_free.ml) ../stdlib-412/stdlib side_effect_free.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets incomplete_toplevel_test.cmi incomplete_toplevel_test.cmj)
     (deps (:inputs incomplete_toplevel_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets infer_type_test.cmj)
     (deps (:inputs infer_type_test.ml) ../stdlib-412/stdlib infer_type_test.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets infer_type_test.cmi)
     (deps (:inputs infer_type_test.mli) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets inline_const.cmj)
     (deps (:inputs inline_const.ml) ../stdlib-412/stdlib inline_const.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets inline_const.cmi)
     (deps (:inputs inline_const.mli) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets inline_const_test.cmi inline_const_test.cmj)
     (deps (:inputs inline_const_test.ml) ../stdlib-412/stdlib inline_const.cmj mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets inline_edge_cases.cmj)
     (deps (:inputs inline_edge_cases.ml) ../stdlib-412/stdlib inline_edge_cases.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets inline_edge_cases.cmi)
     (deps (:inputs inline_edge_cases.mli) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets inline_map2_test.cmi inline_map2_test.cmj)
     (deps (:inputs inline_map2_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets inline_map_test.cmj)
     (deps (:inputs inline_map_test.ml) ../stdlib-412/stdlib inline_map_test.cmi mt.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets inline_map_test.cmi)
     (deps (:inputs inline_map_test.mli) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets inline_record_test.cmi inline_record_test.cmj)
     (deps (:inputs inline_record_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets inline_regression_test.cmi inline_regression_test.cmj)
     (deps (:inputs inline_regression_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets inline_string_test.cmi inline_string_test.cmj)
     (deps (:inputs inline_string_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets inner_call.cmi inner_call.cmj)
     (deps (:inputs inner_call.ml) ../stdlib-412/stdlib inner_define.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets inner_define.cmj)
     (deps (:inputs inner_define.ml) ../stdlib-412/stdlib inner_define.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets inner_define.cmi)
     (deps (:inputs inner_define.mli) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets inner_unused.cmi inner_unused.cmj)
     (deps (:inputs inner_unused.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets installation_test.cmi installation_test.cmj)
     (deps (:inputs installation_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets int32_test.cmi int32_test.cmj)
     (deps (:inputs int32_test.ml) ../stdlib-412/stdlib ext_array_test.cmj mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets int64_mul_div_test.cmi int64_mul_div_test.cmj)
     (deps (:inputs int64_mul_div_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets int64_string_bench.cmi int64_string_bench.cmj)
     (deps (:inputs int64_string_bench.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets int64_string_test.cmi int64_string_test.cmj)
     (deps (:inputs int64_string_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets int64_test.cmi int64_test.cmj)
     (deps (:inputs int64_test.ml) ../stdlib-412/stdlib ext_array_test.cmj mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets int_hashtbl_test.cmi int_hashtbl_test.cmj)
     (deps (:inputs int_hashtbl_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets int_map.cmi int_map.cmj)
     (deps (:inputs int_map.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets int_overflow_test.cmi int_overflow_test.cmj)
     (deps (:inputs int_overflow_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets int_switch_test.cmi int_switch_test.cmj)
     (deps (:inputs int_switch_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets internal_unused_test.cmi internal_unused_test.cmj)
     (deps (:inputs internal_unused_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets io_test.cmi io_test.cmj)
     (deps (:inputs io_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets js_array_test.cmi js_array_test.cmj)
     (deps (:inputs js_array_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets js_bool_test.cmi js_bool_test.cmj)
     (deps (:inputs js_bool_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets js_cast_test.cmi js_cast_test.cmj)
     (deps (:inputs js_cast_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets js_date_test.cmi js_date_test.cmj)
     (deps (:inputs js_date_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets js_dict_test.cmi js_dict_test.cmj)
     (deps (:inputs js_dict_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets js_exception_catch_test.cmi js_exception_catch_test.cmj)
     (deps (:inputs js_exception_catch_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets js_float_test.cmi js_float_test.cmj)
     (deps (:inputs js_float_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets js_global_test.cmi js_global_test.cmj)
     (deps (:inputs js_global_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets js_int_test.cmi js_int_test.cmj)
     (deps (:inputs js_int_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets js_json_test.cmi js_json_test.cmj)
     (deps (:inputs js_json_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets js_list_test.cmi js_list_test.cmj)
     (deps (:inputs js_list_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets js_math_test.cmi js_math_test.cmj)
     (deps (:inputs js_math_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets js_null_test.cmi js_null_test.cmj)
     (deps (:inputs js_null_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets js_null_undefined_test.cmi js_null_undefined_test.cmj)
     (deps (:inputs js_null_undefined_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets js_nullable_test.cmi js_nullable_test.cmj)
     (deps (:inputs js_nullable_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets js_obj_test.cmi js_obj_test.cmj)
     (deps (:inputs js_obj_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets js_option_test.cmi js_option_test.cmj)
     (deps (:inputs js_option_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets js_promise_basic_test.cmi js_promise_basic_test.cmj)
     (deps (:inputs js_promise_basic_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets js_re_test.cmi js_re_test.cmj)
     (deps (:inputs js_re_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets js_string_test.cmi js_string_test.cmj)
     (deps (:inputs js_string_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets js_typed_array_test.cmi js_typed_array_test.cmj)
     (deps (:inputs js_typed_array_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets js_undefined_test.cmi js_undefined_test.cmj)
     (deps (:inputs js_undefined_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets js_val.cmi js_val.cmj)
     (deps (:inputs js_val.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets jsoo_400_test.cmi jsoo_400_test.cmj)
     (deps (:inputs jsoo_400_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets jsoo_485_test.cmi jsoo_485_test.cmj)
     (deps (:inputs jsoo_485_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets key_word_property.cmi key_word_property.cmj)
     (deps (:inputs key_word_property.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets key_word_property2.cmi key_word_property2.cmj)
     (deps (:inputs key_word_property2.ml) ../stdlib-412/stdlib export_keyword.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets key_word_property_plus_test.cmi key_word_property_plus_test.cmj)
     (deps (:inputs key_word_property_plus_test.ml) ../stdlib-412/stdlib global_mangles.cmj mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets label_uncurry.cmi label_uncurry.cmj)
     (deps (:inputs label_uncurry.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets large_obj_test.cmi large_obj_test.cmj)
     (deps (:inputs large_obj_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets large_record_duplication_test.cmi large_record_duplication_test.cmj)
     (deps (:inputs large_record_duplication_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets largest_int_flow.cmi largest_int_flow.cmj)
     (deps (:inputs largest_int_flow.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets lazy_demo.cmi lazy_demo.cmj)
     (deps (:inputs lazy_demo.re) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets lazy_test.cmi lazy_test.cmj)
     (deps (:inputs lazy_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets lexer_test.cmi lexer_test.cmj)
     (deps (:inputs lexer_test.ml) ../stdlib-412/stdlib arith_lexer.cmj arith_parser.cmj arith_syntax.cmj mt.cmj number_lexer.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets lib_js_test.cmi lib_js_test.cmj)
     (deps (:inputs lib_js_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets libarg_test.cmi libarg_test.cmj)
     (deps (:inputs libarg_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets libqueue_test.cmi libqueue_test.cmj)
     (deps (:inputs libqueue_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets limits_test.cmi limits_test.cmj)
     (deps (:inputs limits_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets list_stack.cmi list_stack.cmj)
     (deps (:inputs list_stack.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets list_test.cmi list_test.cmj)
     (deps (:inputs list_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets local_class_type.cmi local_class_type.cmj)
     (deps (:inputs local_class_type.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets local_exception_test.cmi local_exception_test.cmj)
     (deps (:inputs local_exception_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets loop_regression_test.cmi loop_regression_test.cmj)
     (deps (:inputs loop_regression_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets loop_suites_test.cmi loop_suites_test.cmj)
     (deps (:inputs loop_suites_test.ml) ../stdlib-412/stdlib for_loop_test.cmj mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets map_find_test.cmi map_find_test.cmj)
     (deps (:inputs map_find_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets map_test.cmj)
     (deps (:inputs map_test.ml) ../stdlib-412/stdlib map_test.cmi mt.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets map_test.cmi)
     (deps (:inputs map_test.mli) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets mario_game.cmi mario_game.cmj)
     (deps (:inputs mario_game.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets method_chain.cmi method_chain.cmj)
     (deps (:inputs method_chain.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets method_name_test.cmi method_name_test.cmj)
     (deps (:inputs method_name_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets method_string_name.cmi method_string_name.cmj)
     (deps (:inputs method_string_name.re) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets minimal_test.cmi minimal_test.cmj)
     (deps (:inputs minimal_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets miss_colon_test.cmi miss_colon_test.cmj)
     (deps (:inputs miss_colon_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets mock_mt.cmi mock_mt.cmj)
     (deps (:inputs mock_mt.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets module_alias_test.cmi module_alias_test.cmj)
     (deps (:inputs module_alias_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets module_as_class_ffi.cmi module_as_class_ffi.cmj)
     (deps (:inputs module_as_class_ffi.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets module_as_function.cmi module_as_function.cmj)
     (deps (:inputs module_as_function.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets module_missing_conversion.cmi module_missing_conversion.cmj)
     (deps (:inputs module_missing_conversion.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets module_parameter_test.cmi module_parameter_test.cmj)
     (deps (:inputs module_parameter_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets module_splice_test.cmi module_splice_test.cmj)
     (deps (:inputs module_splice_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets more_poly_variant_test.cmi more_poly_variant_test.cmj)
     (deps (:inputs more_poly_variant_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets more_uncurry.cmi more_uncurry.cmj)
     (deps (:inputs more_uncurry.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets mpr_6033_test.cmi mpr_6033_test.cmj)
     (deps (:inputs mpr_6033_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets mt.cmj)
     (deps (:inputs mt.ml) ../stdlib-412/stdlib mt.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets mt.cmi)
     (deps (:inputs mt.mli) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets mt_global.cmj)
     (deps (:inputs mt_global.ml) ../stdlib-412/stdlib mt.cmj mt_global.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets mt_global.cmi)
     (deps (:inputs mt_global.mli) ../stdlib-412/stdlib mt.cmi)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets mutable_obj_test.cmi mutable_obj_test.cmj)
     (deps (:inputs mutable_obj_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets mutable_uncurry_test.cmi mutable_uncurry_test.cmj)
     (deps (:inputs mutable_uncurry_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets mutual_non_recursive_type.cmi mutual_non_recursive_type.cmj)
     (deps (:inputs mutual_non_recursive_type.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets name_mangle_test.cmi name_mangle_test.cmj)
     (deps (:inputs name_mangle_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets nativeint.cmi nativeint.cmj)
     (deps (:inputs nativeint.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets nested_include.cmi nested_include.cmj)
     (deps (:inputs nested_include.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets nested_module_alias.cmi nested_module_alias.cmj)
     (deps (:inputs nested_module_alias.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets nested_obj_literal.cmi nested_obj_literal.cmj)
     (deps (:inputs nested_obj_literal.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets nested_obj_test.cmi nested_obj_test.cmj)
     (deps (:inputs nested_obj_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets nested_pattern_match_test.cmi nested_pattern_match_test.cmj)
     (deps (:inputs nested_pattern_match_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets noassert.cmi noassert.cmj)
     (deps (:inputs noassert.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets node_fs_test.cmi node_fs_test.cmj)
     (deps (:inputs node_fs_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets node_path_test.cmi node_path_test.cmj)
     (deps (:inputs node_path_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets null_list_test.cmi null_list_test.cmj)
     (deps (:inputs null_list_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets number_lexer.cmi number_lexer.cmj)
     (deps (:inputs number_lexer.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets obj_curry_test.cmi obj_curry_test.cmj)
     (deps (:inputs obj_curry_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets obj_literal_ppx.cmi obj_literal_ppx.cmj)
     (deps (:inputs obj_literal_ppx.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets obj_literal_ppx_test.cmi obj_literal_ppx_test.cmj)
     (deps (:inputs obj_literal_ppx_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets obj_magic_test.cmi obj_magic_test.cmj)
     (deps (:inputs obj_magic_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets obj_repr_test.cmi obj_repr_test.cmj)
     (deps (:inputs obj_repr_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets obj_test.cmi obj_test.cmj)
     (deps (:inputs obj_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets obj_type_test.cmi obj_type_test.cmj)
     (deps (:inputs obj_type_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets ocaml_parsetree_test.cmj)
     (deps (:inputs ocaml_parsetree_test.ml) ../stdlib-412/stdlib nativeint.cmj ocaml_parsetree_test.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets ocaml_parsetree_test.cmi)
     (deps (:inputs ocaml_parsetree_test.mli) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets ocaml_proto_test.cmj)
     (deps (:inputs ocaml_proto_test.ml) ../stdlib-412/stdlib mt.cmj ocaml_proto_test.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets ocaml_proto_test.cmi)
     (deps (:inputs ocaml_proto_test.mli) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets ocaml_re_test.cmi ocaml_re_test.cmj)
     (deps (:inputs ocaml_re_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets ocaml_typedtree_test.cmj)
     (deps (:inputs ocaml_typedtree_test.ml) ../stdlib-412/stdlib nativeint.cmj ocaml_typedtree_test.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets ocaml_typedtree_test.cmi)
     (deps (:inputs ocaml_typedtree_test.mli) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets of_string_test.cmi of_string_test.cmj)
     (deps (:inputs of_string_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets offset.cmi offset.cmj)
     (deps (:inputs offset.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets oo_js_test_date.cmi oo_js_test_date.cmj)
     (deps (:inputs oo_js_test_date.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets opr_3576_test.cmi opr_3576_test.cmj)
     (deps (:inputs opr_3576_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets opr_4560_test.cmi opr_4560_test.cmj)
     (deps (:inputs opr_4560_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets option_repr_test.cmi option_repr_test.cmj)
     (deps (:inputs option_repr_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets optional_ffi_test.cmi optional_ffi_test.cmj)
     (deps (:inputs optional_ffi_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets optional_regression_test.cmi optional_regression_test.cmj)
     (deps (:inputs optional_regression_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets parser_api.cmi parser_api.cmj)
     (deps (:inputs parser_api.ml) ../stdlib-412/stdlib nativeint.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets parser_api_test.cmi parser_api_test.cmj)
     (deps (:inputs parser_api_test.ml) ../stdlib-412/stdlib mt.cmj parser_api.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets pipe_send_readline.cmi pipe_send_readline.cmj)
     (deps (:inputs pipe_send_readline.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets pipe_syntax.cmi pipe_syntax.cmj)
     (deps (:inputs pipe_syntax.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets poly_empty_array.cmi poly_empty_array.cmj)
     (deps (:inputs poly_empty_array.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets poly_type.cmi poly_type.cmj)
     (deps (:inputs poly_type.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets poly_variant_test.cmj)
     (deps (:inputs poly_variant_test.ml) ../stdlib-412/stdlib mt.cmj poly_variant_test.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets poly_variant_test.cmi)
     (deps (:inputs poly_variant_test.mli) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets polymorphism_test.cmj)
     (deps (:inputs polymorphism_test.ml) ../stdlib-412/stdlib polymorphism_test.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets polymorphism_test.cmi)
     (deps (:inputs polymorphism_test.mli) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets polyvar_convert.cmi polyvar_convert.cmj)
     (deps (:inputs polyvar_convert.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets polyvar_test.cmi polyvar_test.cmj)
     (deps (:inputs polyvar_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets ppx_apply_test.cmi ppx_apply_test.cmj)
     (deps (:inputs ppx_apply_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets ppx_this_obj_field.cmi ppx_this_obj_field.cmj)
     (deps (:inputs ppx_this_obj_field.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets ppx_this_obj_test.cmi ppx_this_obj_test.cmj)
     (deps (:inputs ppx_this_obj_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets pq_test.cmi pq_test.cmj)
     (deps (:inputs pq_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets pr6726.cmi pr6726.cmj)
     (deps (:inputs pr6726.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets pr_regression_test.cmi pr_regression_test.cmj)
     (deps (:inputs pr_regression_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets prepend_data_ffi.cmi prepend_data_ffi.cmj)
     (deps (:inputs prepend_data_ffi.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets primitive_reg_test.cmi primitive_reg_test.cmj)
     (deps (:inputs primitive_reg_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets print_alpha_test.cmi print_alpha_test.cmj)
     (deps (:inputs print_alpha_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets printf_sim.cmi printf_sim.cmj)
     (deps (:inputs printf_sim.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets printf_test.cmi printf_test.cmj)
     (deps (:inputs printf_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets promise.cmi promise.cmj)
     (deps (:inputs promise.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets promise_catch_test.cmi promise_catch_test.cmj)
     (deps (:inputs promise_catch_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets qcc.cmi qcc.cmj)
     (deps (:inputs qcc.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets queue_402.cmi queue_402.cmj)
     (deps (:inputs queue_402.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets queue_test.cmi queue_test.cmj)
     (deps (:inputs queue_test.ml) ../stdlib-412/stdlib mt.cmj queue_402.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets random_test.cmi random_test.cmj)
     (deps (:inputs random_test.ml) ../stdlib-412/stdlib mt.cmj mt_global.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets raw_hash_tbl_bench.cmi raw_hash_tbl_bench.cmj)
     (deps (:inputs raw_hash_tbl_bench.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets raw_output_test.cmi raw_output_test.cmj)
     (deps (:inputs raw_output_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets raw_pure_test.cmi raw_pure_test.cmj)
     (deps (:inputs raw_pure_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets rbset.cmi rbset.cmj)
     (deps (:inputs rbset.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets re_first_test.cmi re_first_test.cmj)
     (deps (:inputs re_first_test.re) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets react.cmi react.cmj)
     (deps (:inputs react.re) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets reactDOMRe.cmi reactDOMRe.cmj)
     (deps (:inputs reactDOMRe.re) ../stdlib-412/stdlib react.cmj reactEvent.cmj reasonReact.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets reactDOMServerRe.cmi reactDOMServerRe.cmj)
     (deps (:inputs reactDOMServerRe.re) ../stdlib-412/stdlib react.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets reactEvent.cmj)
     (deps (:inputs reactEvent.re) ../stdlib-412/stdlib reactEvent.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets reactEvent.cmi)
     (deps (:inputs reactEvent.rei) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets reactEventRe.cmj)
     (deps (:inputs reactEventRe.re) ../stdlib-412/stdlib reactEvent.cmj reactEventRe.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets reactEventRe.cmi)
     (deps (:inputs reactEventRe.rei) ../stdlib-412/stdlib reactEvent.cmi)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets reactTestUtils.cmj)
     (deps (:inputs reactTestUtils.re) ../stdlib-412/stdlib react.cmj reactTestUtils.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets reactTestUtils.cmi)
     (deps (:inputs reactTestUtils.rei) ../stdlib-412/stdlib react.cmi)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets reasonReact.cmj)
     (deps (:inputs reasonReact.re) ../stdlib-412/stdlib react.cmj reasonReact.cmi reasonReactOptimizedCreateClass.cmj reasonReactRouter.cmj)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets reasonReact.cmi)
     (deps (:inputs reasonReact.rei) ../stdlib-412/stdlib react.cmi reasonReactRouter.cmi)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets reasonReactCompat.cmj)
     (deps (:inputs reasonReactCompat.re) ../stdlib-412/stdlib react.cmj reasonReact.cmj reasonReactCompat.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets reasonReactCompat.cmi)
     (deps (:inputs reasonReactCompat.rei) ../stdlib-412/stdlib react.cmi reasonReact.cmi)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets reasonReactOptimizedCreateClass.cmi reasonReactOptimizedCreateClass.cmj)
     (deps (:inputs reasonReactOptimizedCreateClass.re) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets reasonReactRouter.cmj)
     (deps (:inputs reasonReactRouter.re) ../stdlib-412/stdlib react.cmj reasonReactRouter.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets reasonReactRouter.cmi)
     (deps (:inputs reasonReactRouter.rei) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets rebind_module.cmi rebind_module.cmj)
     (deps (:inputs rebind_module.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets rebind_module_test.cmi rebind_module_test.cmj)
     (deps (:inputs rebind_module_test.ml) ../stdlib-412/stdlib rebind_module.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets rec_fun_test.cmi rec_fun_test.cmj)
     (deps (:inputs rec_fun_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets rec_module_opt.cmi rec_module_opt.cmj)
     (deps (:inputs rec_module_opt.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets rec_module_test.cmi rec_module_test.cmj)
     (deps (:inputs rec_module_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets rec_value_test.cmi rec_value_test.cmj)
     (deps (:inputs rec_value_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets record_debug_test.cmi record_debug_test.cmj)
     (deps (:inputs record_debug_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets record_extension_test.cmi record_extension_test.cmj)
     (deps (:inputs record_extension_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets record_name_test.cmi record_name_test.cmj)
     (deps (:inputs record_name_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets record_with_test.cmi record_with_test.cmj)
     (deps (:inputs record_with_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets recursive_module.cmi recursive_module.cmj)
     (deps (:inputs recursive_module.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets recursive_module_test.cmi recursive_module_test.cmj)
     (deps (:inputs recursive_module_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets recursive_react_component.cmi recursive_react_component.cmj)
     (deps (:inputs recursive_react_component.re) ../stdlib-412/stdlib react.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets recursive_records_test.cmi recursive_records_test.cmj)
     (deps (:inputs recursive_records_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets recursive_unbound_module_test.cmi recursive_unbound_module_test.cmj)
     (deps (:inputs recursive_unbound_module_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets regression_print.cmi regression_print.cmj)
     (deps (:inputs regression_print.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets relative_path.cmi relative_path.cmj)
     (deps (:inputs relative_path.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets return_check.cmi return_check.cmj)
     (deps (:inputs return_check.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets runtime_encoding_test.cmi runtime_encoding_test.cmj)
     (deps (:inputs runtime_encoding_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets scanf_io.cmi scanf_io.cmj)
     (deps (:inputs scanf_io.ml) ../stdlib-412/stdlib testing.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets scanf_reference_error_regression_test.cmj)
     (deps (:inputs scanf_reference_error_regression_test.ml) ../stdlib-412/stdlib mt.cmj mt_global.cmj scanf_reference_error_regression_test.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets scanf_reference_error_regression_test.cmi)
     (deps (:inputs scanf_reference_error_regression_test.mli) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets scanf_test.cmi scanf_test.cmj)
     (deps (:inputs scanf_test.ml) ../stdlib-412/stdlib mt.cmj mt_global.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets set_gen.cmi set_gen.cmj)
     (deps (:inputs set_gen.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets sexp.cmj)
     (deps (:inputs sexp.ml) ../stdlib-412/stdlib sexp.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets sexp.cmi)
     (deps (:inputs sexp.mli) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets sexpm.cmj)
     (deps (:inputs sexpm.ml) ../stdlib-412/stdlib sexpm.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets sexpm.cmi)
     (deps (:inputs sexpm.mli) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets sexpm_test.cmi sexpm_test.cmj)
     (deps (:inputs sexpm_test.ml) ../stdlib-412/stdlib mt.cmj sexpm.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets side_effect.cmi side_effect.cmj)
     (deps (:inputs side_effect.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets side_effect_free.cmi side_effect_free.cmj)
     (deps (:inputs side_effect_free.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets simple_derive_test.cmj)
     (deps (:inputs simple_derive_test.ml) ../stdlib-412/stdlib simple_derive_test.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets simple_derive_test.cmi)
     (deps (:inputs simple_derive_test.mli) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets simple_derive_use.cmj)
     (deps (:inputs simple_derive_use.ml) ../stdlib-412/stdlib simple_derive_use.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets simple_derive_use.cmi)
     (deps (:inputs simple_derive_use.mli) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets simple_lexer_test.cmi simple_lexer_test.cmj)
     (deps (:inputs simple_lexer_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets simplify_lambda_632o.cmi simplify_lambda_632o.cmj)
     (deps (:inputs simplify_lambda_632o.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets single_module_alias.cmi single_module_alias.cmj)
     (deps (:inputs single_module_alias.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets singular_unit_test.cmi singular_unit_test.cmj)
     (deps (:inputs singular_unit_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets small_inline_test.cmi small_inline_test.cmj)
     (deps (:inputs small_inline_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets splice_test.cmi splice_test.cmj)
     (deps (:inputs splice_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets sprintf_reg_test.cmi sprintf_reg_test.cmj)
     (deps (:inputs sprintf_reg_test.ml) ../stdlib-412/stdlib mt.cmj mt_global.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets stack_comp_test.cmi stack_comp_test.cmj)
     (deps (:inputs stack_comp_test.ml) ../stdlib-412/stdlib mt.cmj mt_global.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets stack_test.cmi stack_test.cmj)
     (deps (:inputs stack_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets stream_parser_test.cmi stream_parser_test.cmj)
     (deps (:inputs stream_parser_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets string_bound_get_test.cmi string_bound_get_test.cmj)
     (deps (:inputs string_bound_get_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets string_get_set_test.cmi string_get_set_test.cmj)
     (deps (:inputs string_get_set_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets string_interp_test.cmi string_interp_test.cmj)
     (deps (:inputs string_interp_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets string_literal_print_test.cmi string_literal_print_test.cmj)
     (deps (:inputs string_literal_print_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets string_runtime_test.cmi string_runtime_test.cmj)
     (deps (:inputs string_runtime_test.ml) ../stdlib-412/stdlib mt.cmj test_char.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets string_set.cmi string_set.cmj)
     (deps (:inputs string_set.ml) ../stdlib-412/stdlib set_gen.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets string_set_test.cmi string_set_test.cmj)
     (deps (:inputs string_set_test.ml) ../stdlib-412/stdlib mt.cmj string_set.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets string_test.cmi string_test.cmj)
     (deps (:inputs string_test.ml) ../stdlib-412/stdlib ext_string_test.cmj mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets string_unicode_test.cmi string_unicode_test.cmj)
     (deps (:inputs string_unicode_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets stringmatch_test.cmi stringmatch_test.cmj)
     (deps (:inputs stringmatch_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets submodule.cmi submodule.cmj)
     (deps (:inputs submodule.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets submodule_call.cmi submodule_call.cmj)
     (deps (:inputs submodule_call.ml) ../stdlib-412/stdlib submodule.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets swap_test.cmi swap_test.cmj)
     (deps (:inputs swap_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets switch_case_test.cmi switch_case_test.cmj)
     (deps (:inputs switch_case_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets tailcall_inline_test.cmi tailcall_inline_test.cmj)
     (deps (:inputs tailcall_inline_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test.cmi test.cmj)
     (deps (:inputs test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_alias.cmi test_alias.cmj)
     (deps (:inputs test_alias.ml) ../stdlib-412/stdlib test_global_print.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_ari.cmi test_ari.cmj)
     (deps (:inputs test_ari.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_array.cmi test_array.cmj)
     (deps (:inputs test_array.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_array_append.cmi test_array_append.cmj)
     (deps (:inputs test_array_append.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_array_primitive.cmi test_array_primitive.cmj)
     (deps (:inputs test_array_primitive.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_bool_equal.cmi test_bool_equal.cmj)
     (deps (:inputs test_bool_equal.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_bs_this.cmi test_bs_this.cmj)
     (deps (:inputs test_bs_this.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_bug.cmi test_bug.cmj)
     (deps (:inputs test_bug.ml) ../stdlib-412/stdlib test_char.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_bytes.cmi test_bytes.cmj)
     (deps (:inputs test_bytes.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_case_opt_collision.cmi test_case_opt_collision.cmj)
     (deps (:inputs test_case_opt_collision.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_case_set.cmi test_case_set.cmj)
     (deps (:inputs test_case_set.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_char.cmi test_char.cmj)
     (deps (:inputs test_char.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_closure.cmi test_closure.cmj)
     (deps (:inputs test_closure.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_common.cmi test_common.cmj)
     (deps (:inputs test_common.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_const_elim.cmi test_const_elim.cmj)
     (deps (:inputs test_const_elim.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_const_propogate.cmi test_const_propogate.cmj)
     (deps (:inputs test_const_propogate.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_cpp.cmi test_cpp.cmj)
     (deps (:inputs test_cpp.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_cps.cmi test_cps.cmj)
     (deps (:inputs test_cps.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_demo.cmi test_demo.cmj)
     (deps (:inputs test_demo.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_dup_param.cmi test_dup_param.cmj)
     (deps (:inputs test_dup_param.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_eq.cmi test_eq.cmj)
     (deps (:inputs test_eq.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_exception.cmi test_exception.cmj)
     (deps (:inputs test_exception.ml) ../stdlib-412/stdlib test_common.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_exception_escape.cmi test_exception_escape.cmj)
     (deps (:inputs test_exception_escape.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_export2.cmi test_export2.cmj)
     (deps (:inputs test_export2.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_external.cmi test_external.cmj)
     (deps (:inputs test_external.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_external_unit.cmi test_external_unit.cmj)
     (deps (:inputs test_external_unit.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_ffi.cmi test_ffi.cmj)
     (deps (:inputs test_ffi.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_fib.cmi test_fib.cmj)
     (deps (:inputs test_fib.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_filename.cmi test_filename.cmj)
     (deps (:inputs test_filename.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_for_loop.cmi test_for_loop.cmj)
     (deps (:inputs test_for_loop.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_for_map.cmi test_for_map.cmj)
     (deps (:inputs test_for_map.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_for_map2.cmj)
     (deps (:inputs test_for_map2.ml) ../stdlib-412/stdlib int_map.cmj test_for_map2.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_for_map2.cmi)
     (deps (:inputs test_for_map2.mli) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_format.cmi test_format.cmj)
     (deps (:inputs test_format.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_formatter.cmi test_formatter.cmj)
     (deps (:inputs test_formatter.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_functor_dead_code.cmi test_functor_dead_code.cmj)
     (deps (:inputs test_functor_dead_code.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_generative_module.cmi test_generative_module.cmj)
     (deps (:inputs test_generative_module.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_global_print.cmi test_global_print.cmj)
     (deps (:inputs test_global_print.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_google_closure.cmi test_google_closure.cmj)
     (deps (:inputs test_google_closure.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_http_server.cmj)
     (deps (:inputs test_http_server.ml) ../stdlib-412/stdlib http_types.cmj test_http_server.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_http_server.cmi)
     (deps (:inputs test_http_server.mli) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_include.cmi test_include.cmj)
     (deps (:inputs test_include.ml) ../stdlib-412/stdlib test_order.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_incomplete.cmi test_incomplete.cmj)
     (deps (:inputs test_incomplete.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_incr_ref.cmi test_incr_ref.cmj)
     (deps (:inputs test_incr_ref.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_index.cmi test_index.cmj)
     (deps (:inputs test_index.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_int_map_find.cmi test_int_map_find.cmj)
     (deps (:inputs test_int_map_find.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_internalOO.cmi test_internalOO.cmj)
     (deps (:inputs test_internalOO.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_is_js.cmj)
     (deps (:inputs test_is_js.ml) ../stdlib-412/stdlib mt.cmj test_is_js.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_is_js.cmi)
     (deps (:inputs test_is_js.mli) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_js_ffi.cmi test_js_ffi.cmj)
     (deps (:inputs test_js_ffi.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_let.cmi test_let.cmj)
     (deps (:inputs test_let.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_list.cmi test_list.cmj)
     (deps (:inputs test_list.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_literal.cmi test_literal.cmj)
     (deps (:inputs test_literal.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_literals.cmi test_literals.cmj)
     (deps (:inputs test_literals.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_match_exception.cmi test_match_exception.cmj)
     (deps (:inputs test_match_exception.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_mutliple.cmi test_mutliple.cmj)
     (deps (:inputs test_mutliple.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_nat64.cmi test_nat64.cmj)
     (deps (:inputs test_nat64.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_nested_let.cmi test_nested_let.cmj)
     (deps (:inputs test_nested_let.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_nested_print.cmi test_nested_print.cmj)
     (deps (:inputs test_nested_print.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_non_export.cmi test_non_export.cmj)
     (deps (:inputs test_non_export.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_nullary.cmi test_nullary.cmj)
     (deps (:inputs test_nullary.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_obj.cmi test_obj.cmj)
     (deps (:inputs test_obj.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_obj_simple_ffi.cmi test_obj_simple_ffi.cmj)
     (deps (:inputs test_obj_simple_ffi.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_order.cmi test_order.cmj)
     (deps (:inputs test_order.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_order_tailcall.cmi test_order_tailcall.cmj)
     (deps (:inputs test_order_tailcall.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_other_exn.cmi test_other_exn.cmj)
     (deps (:inputs test_other_exn.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_pack.cmi test_pack.cmj)
     (deps (:inputs test_pack.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_per.cmi test_per.cmj)
     (deps (:inputs test_per.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_pervasive.cmi test_pervasive.cmj)
     (deps (:inputs test_pervasive.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_pervasives2.cmi test_pervasives2.cmj)
     (deps (:inputs test_pervasives2.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_pervasives3.cmi test_pervasives3.cmj)
     (deps (:inputs test_pervasives3.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_primitive.cmi test_primitive.cmj)
     (deps (:inputs test_primitive.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_promise_bind.cmi test_promise_bind.cmj)
     (deps (:inputs test_promise_bind.ml) ../stdlib-412/stdlib promise.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_ramification.cmi test_ramification.cmj)
     (deps (:inputs test_ramification.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_react.cmi test_react.cmj)
     (deps (:inputs test_react.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_react_case.cmi test_react_case.cmj)
     (deps (:inputs test_react_case.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_regex.cmi test_regex.cmj)
     (deps (:inputs test_regex.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_require.cmi test_require.cmj)
     (deps (:inputs test_require.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_runtime_encoding.cmi test_runtime_encoding.cmj)
     (deps (:inputs test_runtime_encoding.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_scope.cmi test_scope.cmj)
     (deps (:inputs test_scope.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_seq.cmi test_seq.cmj)
     (deps (:inputs test_seq.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_set.cmi test_set.cmj)
     (deps (:inputs test_set.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_side_effect_functor.cmi test_side_effect_functor.cmj)
     (deps (:inputs test_side_effect_functor.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_simple_include.cmi test_simple_include.cmj)
     (deps (:inputs test_simple_include.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_simple_obj.cmi test_simple_obj.cmj)
     (deps (:inputs test_simple_obj.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_simple_pattern_match.cmi test_simple_pattern_match.cmj)
     (deps (:inputs test_simple_pattern_match.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_simple_ref.cmi test_simple_ref.cmj)
     (deps (:inputs test_simple_ref.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_simple_tailcall.cmi test_simple_tailcall.cmj)
     (deps (:inputs test_simple_tailcall.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_small.cmi test_small.cmj)
     (deps (:inputs test_small.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_sprintf.cmi test_sprintf.cmj)
     (deps (:inputs test_sprintf.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_stack.cmi test_stack.cmj)
     (deps (:inputs test_stack.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_static_catch_ident.cmi test_static_catch_ident.cmj)
     (deps (:inputs test_static_catch_ident.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_string.cmi test_string.cmj)
     (deps (:inputs test_string.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_string_case.cmi test_string_case.cmj)
     (deps (:inputs test_string_case.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_string_const.cmi test_string_const.cmj)
     (deps (:inputs test_string_const.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_string_map.cmi test_string_map.cmj)
     (deps (:inputs test_string_map.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_string_switch.cmi test_string_switch.cmj)
     (deps (:inputs test_string_switch.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_switch.cmi test_switch.cmj)
     (deps (:inputs test_switch.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_trywith.cmi test_trywith.cmj)
     (deps (:inputs test_trywith.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_tuple.cmi test_tuple.cmj)
     (deps (:inputs test_tuple.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_tuple_destructring.cmi test_tuple_destructring.cmj)
     (deps (:inputs test_tuple_destructring.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_type_based_arity.cmi test_type_based_arity.cmj)
     (deps (:inputs test_type_based_arity.ml) ../stdlib-412/stdlib abstract_type.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_u.cmi test_u.cmj)
     (deps (:inputs test_u.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_unsafe_cmp.cmi test_unsafe_cmp.cmj)
     (deps (:inputs test_unsafe_cmp.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_unsafe_obj_ffi.cmj)
     (deps (:inputs test_unsafe_obj_ffi.ml) ../stdlib-412/stdlib test_unsafe_obj_ffi.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_unsafe_obj_ffi.cmi)
     (deps (:inputs test_unsafe_obj_ffi.mli) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_unsafe_obj_ffi_ppx.cmj)
     (deps (:inputs test_unsafe_obj_ffi_ppx.ml) ../stdlib-412/stdlib test_unsafe_obj_ffi_ppx.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_unsafe_obj_ffi_ppx.cmi)
     (deps (:inputs test_unsafe_obj_ffi_ppx.mli) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_unsupported_primitive.cmi test_unsupported_primitive.cmj)
     (deps (:inputs test_unsupported_primitive.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_while_closure.cmi test_while_closure.cmj)
     (deps (:inputs test_while_closure.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_while_side_effect.cmi test_while_side_effect.cmj)
     (deps (:inputs test_while_side_effect.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets test_zero_nullable.cmi test_zero_nullable.cmj)
     (deps (:inputs test_zero_nullable.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets testing.cmj)
     (deps (:inputs testing.ml) ../stdlib-412/stdlib testing.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets testing.cmi)
     (deps (:inputs testing.mli) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets tfloat_record_test.cmi tfloat_record_test.cmj)
     (deps (:inputs tfloat_record_test.ml) ../stdlib-412/stdlib float_array.cmj float_record.cmj mt.cmj mt_global.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets ticker.cmi ticker.cmj)
     (deps (:inputs ticker.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets to_string_test.cmi to_string_test.cmj)
     (deps (:inputs to_string_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets topsort_test.cmi topsort_test.cmj)
     (deps (:inputs topsort_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets tramp_fib.cmi tramp_fib.cmj)
     (deps (:inputs tramp_fib.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets tscanf_test.cmi tscanf_test.cmj)
     (deps (:inputs tscanf_test.ml) ../stdlib-412/stdlib mt.cmj mt_global.cmj testing.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets tuple_alloc.cmi tuple_alloc.cmj)
     (deps (:inputs tuple_alloc.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets type_disambiguate.cmi type_disambiguate.cmj)
     (deps (:inputs type_disambiguate.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets typeof_test.cmi typeof_test.cmj)
     (deps (:inputs typeof_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets ui_defs.cmi)
     (deps (:inputs ui_defs.mli) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets unboxed_attribute_test.cmi unboxed_attribute_test.cmj)
     (deps (:inputs unboxed_attribute_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets unboxed_use_case.cmj)
     (deps (:inputs unboxed_use_case.ml) ../stdlib-412/stdlib unboxed_use_case.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets unboxed_use_case.cmi)
     (deps (:inputs unboxed_use_case.mli) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets uncurry_glob_test.cmi uncurry_glob_test.cmj)
     (deps (:inputs uncurry_glob_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets uncurry_method.cmi uncurry_method.cmj)
     (deps (:inputs uncurry_method.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets uncurry_test.cmj)
     (deps (:inputs uncurry_test.ml) ../stdlib-412/stdlib uncurry_test.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets uncurry_test.cmi)
     (deps (:inputs uncurry_test.mli) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets undef_regression2_test.cmi undef_regression2_test.cmj)
     (deps (:inputs undef_regression2_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets undef_regression_test.cmi undef_regression_test.cmj)
     (deps (:inputs undef_regression_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets unicode_type_error.cmi unicode_type_error.cmj)
     (deps (:inputs unicode_type_error.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets unit_undefined_test.cmi unit_undefined_test.cmj)
     (deps (:inputs unit_undefined_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets unitest_string.cmi unitest_string.cmj)
     (deps (:inputs unitest_string.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets unsafe_full_apply_primitive.cmi unsafe_full_apply_primitive.cmj)
     (deps (:inputs unsafe_full_apply_primitive.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets unsafe_obj_external.cmi unsafe_obj_external.cmj)
     (deps (:inputs unsafe_obj_external.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets unsafe_ppx_test.cmi unsafe_ppx_test.cmj)
     (deps (:inputs unsafe_ppx_test.ml) ../stdlib-412/stdlib ffi_js_test.cmj mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets unsafe_this.cmj)
     (deps (:inputs unsafe_this.ml) ../stdlib-412/stdlib unsafe_this.cmi)
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets unsafe_this.cmi)
     (deps (:inputs unsafe_this.mli) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets update_record_test.cmi update_record_test.cmj)
     (deps (:inputs update_record_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets utf8_decode_test.cmi utf8_decode_test.cmj)
     (deps (:inputs utf8_decode_test.ml) ../stdlib-412/stdlib mt.cmj)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets variant.cmi variant.cmj)
     (deps (:inputs variant.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets watch_test.cmi watch_test.cmj)
     (deps (:inputs watch_test.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 
 
   (rule
     (targets webpack_config.cmi webpack_config.cmj)
     (deps (:inputs webpack_config.ml) ../stdlib-412/stdlib)
     (action
-     (run bsc.exe -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I ../runtime -I ../stdlib-412 -I ../others -I . %{inputs})))
 

--- a/scripts/ninja.js
+++ b/scripts/ninja.js
@@ -122,7 +122,7 @@ function ruleCC(flags, src, target, deps = []) {
     (targets ${Array.isArray(target) ? target.join(' ') : target})
     (deps (:inputs ${Array.isArray(src) ? src.join(' ') : src}) ${deps.join(' ')})
     (action
-     (run bsc.exe -bs-cmi -bs-cmj ${flags} -I . %{inputs})))
+     (run bsc -bs-cmi -bs-cmj ${flags} -I . %{inputs})))
 `;
 }
 
@@ -132,7 +132,7 @@ function ruleCC_cmi(flags, src, target, deps = []) {
     (targets ${Array.isArray(target) ? target.join(' ') : target})
     (deps (:inputs ${Array.isArray(src) ? src.join(' ') : src}) ${deps.join(' ')})
     (action
-     (run bsc.exe -bs-read-cmi -bs-cmi -bs-cmj ${flags} -I . %{inputs})))
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj ${flags} -I . %{inputs})))
 `;
 }
 


### PR DESCRIPTION
This does the changes needed to be able to build the project itself on Windows.

## Breaking Change

The `.exe` suffix was removed as it's not needed and it breaks dune on Windows. So the binaries are now `bsc`, `bsb`, `bspack`, `bsb_helper`, `bsb_parse_depend`

## Bug fix

When the stdlib needed quotes it was adding quotes two times, one when making the global_config and the other one when including the files

## Related

- #34 
