### PR TITLE
Fix runtime for: lazy, Printexc, refs, obj, hashtbl

### DIFF
--- a/jscomp/core/lam_analysis.ml
+++ b/jscomp/core/lam_analysis.ml
@@ -1,5 +1,5 @@
 (* Copyright (C) 2015-2016 Bloomberg Finance L.P.
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -17,74 +17,75 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
 
 (**used in effect analysis, it is sound but not-complete *)
-let not_zero_constant ( x : Lam_constant.t) =  
-  match x with 
+let not_zero_constant ( x : Lam_constant.t) =
+  match x with
   | Const_int {i }  -> i <> 0l
   | Const_int64 i  -> i <> 0L
-  | _ -> false 
+  | _ -> false
 
 
-let rec no_side_effects (lam : Lam.t) : bool = 
-  match lam with 
-  | Lvar _ 
-  | Lconst _ 
+let rec no_side_effects (lam : Lam.t) : bool =
+  match lam with
+  | Lvar _
+  | Lconst _
   | Lfunction _ -> true
-  | Lglobal_module _ -> true 
-    (* we record side effect in the global level, 
+  | Lglobal_module _ -> true
+    (* we record side effect in the global level,
       this expression itself is side effect free
     *)
-  | Lprim {primitive;  args; _} -> 
-    Ext_list.for_all args  no_side_effects && 
+  | Lprim {primitive;  args; _} ->
+    Ext_list.for_all args  no_side_effects &&
     (
-      match primitive with 
+      match primitive with
       | Pccall {prim_name } ->
-        begin 
-          match prim_name,args with 
+        begin
+          match prim_name,args with
           | ("caml_register_named_value"
             (* register to c runtime does not make sense  in ocaml *)
             | "caml_int64_float_of_bits"
              (* more safe to check if arguments are constant *)
-            (* non-observable side effect *)    
+            (* non-observable side effect *)
             | "caml_sys_get_config"
-            | "caml_sys_get_argv" (* should be fine *)
+            | "caml_sys_argv" (* should be fine *)
+            | "caml_sys_executable_name"
             | "caml_string_repeat"
             | "caml_make_vect"
             | "caml_create_bytes"
             | "caml_obj_dup"
-            | "caml_array_dup" 
+            | "caml_array_dup"
 
-            | "nativeint_add"         
+            | "nativeint_add"
             | "nativeint_div"
             | "nativeint_mod"
-            | "nativeint_lsr"  
+            | "nativeint_lsr"
             | "nativeint_mul"
 
-            ), _  -> true 
-          | "caml_ml_open_descriptor_in", [Lconst (  (Const_int {i = 0l}))] -> true 
-          | "caml_ml_open_descriptor_out", 
+            ), _  -> true
+          | "caml_ml_open_descriptor_in", [Lconst (  (Const_int {i = 0l}))] -> true
+          | "caml_ml_open_descriptor_out",
             [Lconst (  (Const_int {i = 1l|2l})) ]
             -> true
           (* we can not mark it pure
              only when we guarantee this exception is caught...
            *)
           | _ , _-> false
-        end 
+        end
       | Pmodint
-      | Pdivint 
+      | Pdivint
       | Pdivint64
       | Pmodint64
-        -> begin match args with 
-          | [_ ; Lconst cst ] -> not_zero_constant cst 
-          | _ -> false 
+        -> begin match args with
+          | [_ ; Lconst cst ] -> not_zero_constant cst
+          | _ -> false
         end
-      
+
       | Pcreate_extension _
       | Pjs_typeof
       | Pis_null
@@ -93,61 +94,61 @@ let rec no_side_effects (lam : Lam.t) : bool =
       | Psome_not_nest
       | Pis_undefined
       | Pis_null_undefined
-      | Pnull_to_opt       
-      | Pundefined_to_opt         
-      | Pnull_undefined_to_opt 
-      | Pjs_fn_make _         
+      | Pnull_to_opt
+      | Pundefined_to_opt
+      | Pnull_undefined_to_opt
+      | Pjs_fn_make _
       | Pjs_object_create _
-        (** TODO: check *)      
-      | Pbytes_to_string 
-      | Pbytes_of_string 
+        (** TODO: check *)
+      | Pbytes_to_string
+      | Pbytes_of_string
       | Pmakeblock _  (* whether it's mutable or not *)
       | Pfield _
       | Pfield_computed
       | Pval_from_option
       | Pval_from_option_not_nest
         (* NOP The compiler already [t option] is the same as t *)
-      | Pduprecord _ 
+      | Pduprecord _
       (* Boolean operations *)
       | Psequand | Psequor | Pnot
       (* Integer operations *)
-      | Pnegint | Paddint | Psubint | Pmulint 
-     
+      | Pnegint | Paddint | Psubint | Pmulint
+
       | Pandint | Porint | Pxorint
       | Plslint | Plsrint | Pasrint
-      | Pintcomp _ 
+      | Pintcomp _
       (* Float operations *)
       | Pintoffloat | Pfloatofint
-      | Pnegfloat 
+      | Pnegfloat
       (* | Pabsfloat *)
-      | Paddfloat | Psubfloat | Pmulfloat 
+      | Paddfloat | Psubfloat | Pmulfloat
       | Pdivfloat
-      | Pfloatcomp _ 
+      | Pfloatcomp _
       | Pjscomp _
       (* String operations *)
-      | Pstringlength 
-      | Pstringrefu 
+      | Pstringlength
+      | Pstringrefu
       | Pstringrefs
       | Pbyteslength
       | Pbytesrefu
       | Pbytesrefs
-      | Pmakearray 
-      | Parraylength  
-      | Parrayrefu 
-      | Parrayrefs  
+      | Pmakearray
+      | Parraylength
+      | Parrayrefu
+      | Parrayrefs
       (* Test if the argument is a block or an immediate integer *)
       | Pisint
       | Pis_poly_var_const
       (* Test if the (integer) argument is outside an interval *)
       | Pisout _
-      | Pint64ofint 
-      | Pintofint64 
+      | Pint64ofint
+      | Pintofint64
       | Pnegint64
-      | Paddint64 
+      | Paddint64
       | Psubint64
       | Pmulint64
-      | Pandint64 
-      | Porint64 
+      | Pandint64
+      | Porint64
       | Pxorint64
       | Plslint64
       | Plsrint64
@@ -160,7 +161,7 @@ let rec no_side_effects (lam : Lam.t) : bool =
       (* Integer to external pointer *)
 
       | Poffsetint _
-      | Pstringadd 
+      | Pstringadd
       | Pjs_function_length
       | Pcaml_obj_length
       | Pwrap_exn
@@ -168,61 +169,61 @@ let rec no_side_effects (lam : Lam.t) : bool =
         -> true
       | Pjs_apply
       | Pjs_runtime_apply
-      | Pjs_call _ 
+      | Pjs_call _
       | Pinit_mod
       | Pupdate_mod
       | Pjs_unsafe_downgrade _
-      | Pdebugger 
-      | Pvoid_run 
+      | Pdebugger
+      | Pvoid_run
       | Pfull_apply
-      | Pjs_fn_method 
+      | Pjs_fn_method
       (* TODO *)
       | Praw_js_code _
-      | Pbytessetu 
+      | Pbytessetu
       | Pbytessets
       (* Operations on boxed integers (Nativeint.t, Int32.t, Int64.t) *)
-      | Parraysets 
+      | Parraysets
       (* byte swap *)
-      | Parraysetu  
-      | Poffsetref _ 
+      | Parraysetu
+      | Poffsetref _
       | Praise
-      | Plazyforce 
-      | Psetfield _ 
+      | Plazyforce
+      | Psetfield _
       | Psetfield_computed
-        -> false 
+        -> false
     )
-  | Llet (_,_, arg,body) -> no_side_effects arg && no_side_effects body 
-  | Lswitch (_,_) -> false 
+  | Llet (_,_, arg,body) -> no_side_effects arg && no_side_effects body
+  | Lswitch (_,_) -> false
   | Lstringswitch (_,_,_) -> false
   | Lstaticraise _ -> false
-  | Lstaticcatch _ -> false 
-  (** It would be nice that we can also analysis some small functions 
-      for example [String.contains], 
+  | Lstaticcatch _ -> false
+  (** It would be nice that we can also analysis some small functions
+      for example [String.contains],
       [Format.make_queue_elem]
   *)
-  | Ltrywith (body,_exn,handler) 
+  | Ltrywith (body,_exn,handler)
     -> no_side_effects body && no_side_effects handler
 
-  | Lifthenelse  (a,b,c) -> 
+  | Lifthenelse  (a,b,c) ->
     no_side_effects a && no_side_effects b && no_side_effects c
   | Lsequence (a,b) -> no_side_effects a && no_side_effects b
   | Lletrec (bindings, body) ->
     Ext_list.for_all_snd bindings no_side_effects && no_side_effects body
   | Lwhile _ -> false (* conservative here, non-terminating loop does have side effect *)
-  | Lfor _ -> false 
+  | Lfor _ -> false
   | Lassign _ -> false (* actually it depends ... *)
-  | Lsend _ -> false 
+  | Lsend _ -> false
   | Lapply {
       ap_func = Lprim {primitive = Pfield (_, Fld_module {name = "from_fun"})};
      ap_args = [arg]}
-        -> no_side_effects arg 
+        -> no_side_effects arg
   | Lapply _ -> false (* we need purity analysis .. *)
-  
 
 
-(* 
-    Estimate the size of lambda for better inlining 
-    threshold is 1000 - so that we 
+
+(*
+    Estimate the size of lambda for better inlining
+    threshold is 1000 - so that we
  *)
 exception Too_big_to_inline
 
@@ -230,82 +231,82 @@ let really_big () = raise_notrace Too_big_to_inline
 
 (* let big_lambda = 1000 *)
 
-let rec size (lam : Lam.t) = 
-  try 
-    match lam with 
+let rec size (lam : Lam.t) =
+  try
+    match lam with
     | Lvar _ ->  1
     | Lconst c -> size_constant c
-    | Llet(_, _, l1, l2) -> 1 + size l1 + size l2 
+    | Llet(_, _, l1, l2) -> 1 + size l1 + size l2
     | Lletrec _ -> really_big ()
-    | Lprim{primitive = Pfield (_, Fld_module _); 
+    | Lprim{primitive = Pfield (_, Fld_module _);
             args =  [ Lglobal_module _ | Lvar _ ]
            ;  _}
       -> 1
-    | Lprim {primitive = Praise | Pis_not_none ; args =  [l ];  _} 
+    | Lprim {primitive = Praise | Pis_not_none ; args =  [l ];  _}
       -> size l
-    | Lglobal_module _ -> 1       
-    | Lprim {primitive = 
-        Praw_js_code _ 
+    | Lglobal_module _ -> 1
+    | Lprim {primitive =
+        Praw_js_code _
       } -> really_big ()
     | Lprim {args = ll; _} -> size_lams 1 ll
 
-    (** complicated 
+    (** complicated
         1. inline this function
         2. ...
         exports.Make=
         function(funarg)
         {var $$let=Make(funarg);
         return [0, $$let[5],... $$let[16]]}
-     *)      
+     *)
     | Lapply{ ap_func;
              ap_args; _} -> size_lams (size ap_func) ap_args
     (* | Lfunction(_, params, l) -> really_big () *)
-    | Lfunction {body} -> size body 
+    | Lfunction {body} -> size body
     | Lswitch _ -> really_big ()
     | Lstringswitch(_,_,_) -> really_big ()
-    | Lstaticraise (_i,ls) -> 
-        Ext_list.fold_left ls 1 (fun acc x -> size x + acc) 
-    | Lstaticcatch _ -> really_big () 
+    | Lstaticraise (_i,ls) ->
+        Ext_list.fold_left ls 1 (fun acc x -> size x + acc)
+    | Lstaticcatch _ -> really_big ()
     | Ltrywith _ -> really_big ()
     | Lifthenelse(l1, l2, l3) -> 1 + size  l1 + size  l2 +  size  l3
     | Lsequence(l1, l2) -> size  l1  +  size  l2
     | Lwhile _ -> really_big ()
-    | Lfor _ -> really_big () 
+    | Lfor _ -> really_big ()
     | Lassign (_,v) -> 1 + size v  (* This is side effectful,  be careful *)
     | Lsend _  ->  really_big ()
 
-  with Too_big_to_inline ->  1000 
-and size_constant x = 
-  match x with 
-  | Const_int _ | Const_char _ 
+  with Too_big_to_inline ->  1000
+and size_constant x =
+  match x with
+  | Const_int _ | Const_char _
 
-  | Const_float _  | Const_int64 _ 
-  | Const_pointer _ 
+  | Const_float _  | Const_int64 _
+  | Const_pointer _
   | Const_js_null | Const_js_undefined | Const_module_alias
   | Const_js_true | Const_js_false
-    -> 1 
+    -> 1
   | Const_unicode _  (* TODO: this seems to be not good heurisitives*)
   | Const_string _ ->  1
-  | Const_some s -> size_constant s   
-  | Const_block (_, _, str) 
-    ->  Ext_list.fold_left str 0 (fun acc x -> acc + size_constant x ) 
+  | Const_some s -> size_constant s
+  | Const_block (_, _, str)
+    ->  Ext_list.fold_left str 0 (fun acc x -> acc + size_constant x )
   | Const_float_array xs  -> List.length xs
 
-and size_lams acc (lams : Lam.t list) = 
-  Ext_list.fold_left lams acc (fun acc l -> acc  + size l ) 
+and size_lams acc (lams : Lam.t list) =
+  Ext_list.fold_left lams acc (fun acc l -> acc  + size l )
 let args_all_const (args : Lam.t list) =
-  Ext_list.for_all args (fun x -> match x with Lconst _ -> true | _ -> false) 
-    
-let exit_inline_size = 7 
+  Ext_list.for_all args (fun x -> match x with Lconst _ -> true | _ -> false)
+
+let exit_inline_size = 7
 let small_inline_size = 5
 
-(** destruct pattern will work better 
+(** destruct pattern will work better
     if it is closed lambda, otherwise
     you can not do full evaluation
 
-    We still should avoid inline too big code, 
+    We still should avoid inline too big code,
 
-    ideally we should also evaluate its size after inlining, 
+    ideally we should also evaluate its size after inlining,
     since after partial evaluation, it might still be *very big*
 *)
 let destruct_pattern (body : Lam.t) params args =
@@ -315,8 +316,8 @@ let destruct_pattern (body : Lam.t) params args =
       if Ident.same x v then Some b
       else aux v xs bs
     | [] , _ -> None
-    | _::_, [] -> assert false                  
-  in   
+    | _::_, [] -> assert false
+  in
   match body with
   | Lswitch (Lvar v , switch)
     ->
@@ -324,31 +325,31 @@ let destruct_pattern (body : Lam.t) params args =
       | Some (Lam.Lconst _ as lam) ->
         size (Lam.switch lam switch) < small_inline_size
       | Some _ | None -> false
-    end        
+    end
   | Lifthenelse(Lvar v, then_, else_)
     -> (* -FIXME *)
     begin match aux v params args with
       | Some (Lconst _ as lam) ->
         size (Lam.if_ lam then_ else_) < small_inline_size
-      | Some _ | None -> false          
-    end      
+      | Some _ | None -> false
+    end
   | _ -> false
-    
+
 (** Hints to inlining *)
-let ok_to_inline_fun_when_app 
+let ok_to_inline_fun_when_app
   (m : Lam.lfunction)
   (args : Lam.t list) =
   match m.attr.inline with
   | Always_inline -> true
   | Never_inline -> false
   | Default_inline ->
-    match m with 
-    | {body; params} -> 
+    match m with
+    | {body; params} ->
     let s = size body in
     s < small_inline_size ||
-    (destruct_pattern body params args) ||  
+    (destruct_pattern body params args) ||
     (args_all_const args &&
-     (s < 10 && no_side_effects body )) 
+     (s < 10 && no_side_effects body ))
 
 
 
@@ -359,13 +360,13 @@ let ok_to_inline_fun_when_app
 (* TODO:  We can relax this a bit later,
     but decide whether to inline it later in the call site
  *)
-let safe_to_inline (lam : Lam.t) = 
-  match lam with 
+let safe_to_inline (lam : Lam.t) =
+  match lam with
   | Lfunction _ ->  true
-  | Lconst 
-    (Const_pointer _  
+  | Lconst
+    (Const_pointer _
     |Const_int {comment = Pt_constructor _}
-    | Const_js_true 
+    | Const_js_true
     | Const_js_false
     | Const_js_undefined
     ) -> true

--- a/jscomp/core/lam_dispatch_primitive.ml
+++ b/jscomp/core/lam_dispatch_primitive.ml
@@ -417,7 +417,8 @@ let translate loc (prim_name : string)
       ->
       call Js_runtime_modules.oo
 
-    | "caml_sys_get_argv"
+    | "caml_sys_executable_name"
+    | "caml_sys_argv"
     (** TODO: refine
         Inlined here is helpful for DCE
         {[ external get_argv: unit -> string * string array = "caml_sys_get_argv" ]}

--- a/jscomp/runtime/caml_sys.ml
+++ b/jscomp/runtime/caml_sys.ml
@@ -1,5 +1,5 @@
 (* Copyright (C) 2015-2016 Bloomberg Finance L.P.
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -17,31 +17,31 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
 
 
-external getEnv : 'a -> string -> string option = "" [@@bs.get_index] 
+external getEnv : 'a -> string -> string option = "" [@@bs.get_index]
 let caml_sys_getenv s =
   if Js.typeof [%raw{|process|}] = "undefined"
-  || [%raw{|process.env|}] = Caml_undefined_extern.empty 
+  || [%raw{|process.env|}] = Caml_undefined_extern.empty
   then raise Not_found
-  else  
-    match getEnv [%raw{|process.env|}] s with 
+  else
+    match getEnv [%raw{|process.env|}] s with
     | None -> raise Not_found
-    | Some x -> x 
+    | Some x -> x
 
-(* https://nodejs.org/dist/latest-v12.x/docs/api/os.html#os_os_platform 
+(* https://nodejs.org/dist/latest-v12.x/docs/api/os.html#os_os_platform
    The value is set at compile time. Possible values are 'aix', 'darwin','freebsd', 'linux', 'openbsd', 'sunos', and 'win32'.
-   The return value is equivalent to process.platform. 
+   The return value is equivalent to process.platform.
    NodeJS does not support Cygwin very well
 *)
 let os_type : unit -> string = [%raw{|function(_){
   if(typeof process !== 'undefined' && process.platform === 'win32'){
-        return "Win32"    
+        return "Win32"
   }
   else {
     return "Unix"
@@ -58,7 +58,7 @@ external uptime : process -> unit -> float = "uptime" [@@bs.send]
 external exit : process -> int -> 'a =  "exit"  [@@bs.send]
 
 let caml_sys_time () =
-  if Js.typeof [%raw{|process|}] = "undefined" 
+  if Js.typeof [%raw{|process|}] = "undefined"
   || [%raw{|process.uptime|}] = Caml_undefined_extern.empty
   then -1.
   else uptime [%raw{|process|}] ()
@@ -70,10 +70,10 @@ let caml_sys_time () =
 type spawnResult
 external spawnSync : string -> spawnResult = "spawnSync" [@@bs.module "child_process"]
 
-external readAs : spawnResult -> 
-  < 
+external readAs : spawnResult ->
+  <
     status : int Js.null;
-  > Js.t = 
+  > Js.t =
   "%identity"
 *)
 
@@ -82,33 +82,40 @@ let caml_sys_system_command _cmd = 127
 
 let caml_sys_getcwd : unit -> string = [%raw{|function(param){
     if (typeof process === "undefined" || process.cwd === undefined){
-      return "/"  
+      return "/"
     }
     return process.cwd()
   }|}]
 
 
+let caml_sys_executable_name () : string =
+  if Js.typeof [%raw{|process|}] = "undefined" then ""
+  else
+    let argv = [%raw{|process.argv|}] in
+    if Js.testAny argv then ""
+    else Caml_array_extern.unsafe_get argv 0
+
 (* Called by {!Sys} in the toplevel, should never fail*)
-let caml_sys_get_argv () : string * string array = 
-  if Js.typeof [%raw{|process|}] = "undefined" then "",[|""|] 
-  else 
-    let argv = [%raw{|process.argv|}] in 
+let caml_sys_argv () : string * string array =
+  if Js.typeof [%raw{|process|}] = "undefined" then "",[|""|]
+  else
+    let argv = [%raw{|process.argv|}] in
     if Js.testAny argv then ("",[|""|])
     else Caml_array_extern.unsafe_get argv 0, argv
 
 (** {!Pervasives.sys_exit} *)
-let caml_sys_exit :int -> 'a = fun exit_code -> 
-  if Js.typeof [%raw{|process|}] <> "undefined"  then 
-    exit [%raw{|process|}] exit_code 
+let caml_sys_exit :int -> 'a = fun exit_code ->
+  if Js.typeof [%raw{|process|}] <> "undefined"  then
+    exit [%raw{|process|}] exit_code
 
 
 
-let caml_sys_is_directory _s = 
+let caml_sys_is_directory _s =
   raise (Failure "caml_sys_is_directory not implemented")
 
-(** Need polyfill to make cmdliner work 
-    {!Sys.is_directory} or {!Sys.file_exists} {!Sys.command} 
+(** Need polyfill to make cmdliner work
+    {!Sys.is_directory} or {!Sys.file_exists} {!Sys.command}
 *)
-let caml_sys_file_exists _s = 
+let caml_sys_file_exists _s =
   raise ( Failure "caml_sys_file_exists not implemented")
 

--- a/jscomp/runtime/caml_sys.mli
+++ b/jscomp/runtime/caml_sys.mli
@@ -1,5 +1,5 @@
 (* Copyright (C) 2015-2016 Bloomberg Finance L.P.
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -17,7 +17,7 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
@@ -26,17 +26,19 @@
 
 val caml_sys_getenv : string -> string
 
-val caml_sys_time : unit -> float 
+val caml_sys_time : unit -> float
 
-val os_type : unit -> string 
+val os_type : unit -> string
 
 val caml_sys_system_command : string -> int
 
-val caml_sys_getcwd : unit -> string 
+val caml_sys_getcwd : unit -> string
 
-val caml_sys_get_argv : unit -> string * string array
+val caml_sys_executable_name : unit -> string
 
-val caml_sys_exit : int -> unit 
+val caml_sys_argv : unit -> string * string array
 
-val caml_sys_is_directory : string -> bool 
-val caml_sys_file_exists : string -> bool 
+val caml_sys_exit : int -> unit
+
+val caml_sys_is_directory : string -> bool
+val caml_sys_file_exists : string -> bool

--- a/jscomp/stdlib-412/stdlib.mli
+++ b/jscomp/stdlib-412/stdlib.mli
@@ -1301,13 +1301,13 @@ type 'a ref = { mutable contents : 'a }
 external ref : 'a -> 'a ref = "%makemutable"
 (** Return a fresh reference containing the given value. *)
 
-external ( ! ) : 'a ref -> 'a = "%field0"
+external ( ! ) : 'a ref -> 'a = "%bs_ref_field0"
 (** [!r] returns the current contents of reference [r].
    Equivalent to [fun r -> r.contents].
    Unary operator, see {!Ocaml_operators} for more information.
 *)
 
-external ( := ) : 'a ref -> 'a -> unit = "%setfield0"
+external ( := ) : 'a ref -> 'a -> unit = "%bs_ref_setfield0"
 (** [r := a] stores the value of [a] in reference [r].
    Equivalent to [fun r v -> r.contents <- v].
    Right-associative operator, see {!Ocaml_operators} for more information.

--- a/jscomp/stdlib-412/stdlib_modules/camlinternalLazy.ml
+++ b/jscomp/stdlib-412/stdlib_modules/camlinternalLazy.ml
@@ -1,73 +1,87 @@
-(**************************************************************************)
-(*                                                                        *)
-(*                                 OCaml                                  *)
-(*                                                                        *)
-(*             Damien Doligez, projet Para, INRIA Rocquencourt            *)
-(*                                                                        *)
-(*   Copyright 1997 Institut National de Recherche en Informatique et     *)
-(*     en Automatique.                                                    *)
-(*                                                                        *)
-(*   All rights reserved.  This file is distributed under the terms of    *)
-(*   the GNU Lesser General Public License version 2.1, with the          *)
-(*   special exception on linking described in the file LICENSE.          *)
-(*                                                                        *)
-(**************************************************************************)
+(* Copyright (C) 2017 Hongbo Zhang, Authors of ReScript
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In addition to the permissions granted to you by the LGPL, you may combine
+ * or link a "work that uses the Library" with a publicly distributed version
+ * of this file to produce a combined library or application, then distribute
+ * that combined work under the terms of your choosing, with no requirement
+ * to comply with the obligations normally placed on you by section 4 of the
+ * LGPL version 3 (or the corresponding section of a later version of the LGPL
+ * should you choose to use a later version).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
+ [@@@bs.config { flags = [|"-bs-no-cross-module-opt" |]}]
 (* Internals of forcing lazy values. *)
 
+(* Internals of forcing lazy values. *)
 type 'a t = 'a lazy_t
+
+type 'a concrete = {
+  mutable tag : bool [@bs.as "LAZY_DONE"] ;
+  (* Invariant: name  *)
+  mutable value : 'a [@bs.as "VAL"]
+  (* its type is ['a] or [unit -> 'a ] *)
+}
 
 exception Undefined
 
-let raise_undefined = Obj.repr (fun () -> raise Undefined)
+external fnToVal : (unit -> 'a [@bs]) -> 'a = "%identity"
+external valToFn :  'a -> (unit -> 'a [@bs])  = "%identity"
+external castToConcrete : 'a lazy_t -> 'a concrete   = "%identity"
+external of_concrete : 'a concrete -> 'a lazy_t   = "%identity"
 
-external make_forward : Obj.t -> Obj.t -> unit = "caml_obj_make_forward"
+let is_val (type a ) (l : a lazy_t) : bool =
+  (castToConcrete l ).tag
+
+
+
+let forward_with_closure (type a ) (blk : a concrete) (closure : unit -> a [@bs]) : a =
+  let result = closure () [@bs] in
+  (* do set_field BEFORE set_tag *)
+  blk.value <- result;
+  blk.tag<- true;
+  result
+
+
+let raise_undefined =  (fun [@bs] () -> raise Undefined)
 
 (* Assume [blk] is a block with tag lazy *)
-let force_lazy_block (blk : 'arg lazy_t) =
-  let closure = (Obj.obj (Obj.field (Obj.repr blk) 0) : unit -> 'arg) in
-  Obj.set_field (Obj.repr blk) 0 raise_undefined;
+let force_lazy_block (type a ) (blk : a t) : a  =
+  let blk = castToConcrete blk in
+  let closure = valToFn blk.value in
+  blk.value <- fnToVal raise_undefined;
   try
-    let result = closure () in
-    make_forward (Obj.repr blk) (Obj.repr result);
-    result
+    forward_with_closure blk closure
   with e ->
-    Obj.set_field (Obj.repr blk) 0 (Obj.repr (fun () -> raise e));
+    blk.value <- fnToVal (fun [@bs] () -> raise e);
     raise e
 
 
 (* Assume [blk] is a block with tag lazy *)
-let force_val_lazy_block (blk : 'arg lazy_t) =
-  let closure = (Obj.obj (Obj.field (Obj.repr blk) 0) : unit -> 'arg) in
-  Obj.set_field (Obj.repr blk) 0 raise_undefined;
-  let result = closure () in
-  make_forward (Obj.repr blk) (Obj.repr result);
-  result
+let force_val_lazy_block (type a ) (blk : a t) : a  =
+  let blk = castToConcrete blk in
+  let closure  = valToFn blk.value  in
+  blk.value <-  fnToVal raise_undefined;
+  forward_with_closure blk closure
 
+let force (type a ) (lzv : a lazy_t) : a =
+  let lzv = (castToConcrete lzv : _ concrete) in
+  if lzv.tag  then lzv.value else
+    force_lazy_block (of_concrete lzv)
 
-(* [force] is not used, since [Lazy.force] is declared as a primitive
-   whose code inlines the tag tests of its argument, except when afl
-   instrumentation is turned on. *)
-
-let force (lzv : 'arg lazy_t) =
-  (* Using [Sys.opaque_identity] prevents two potential problems:
-     - If the value is known to have Forward_tag, then its tag could have
-       changed during GC, so that information must be forgotten (see GPR#713
-       and issue #7301)
-     - If the value is known to be immutable, then if the compiler
-       cannot prove that the last branch is not taken it will issue a
-       warning 59 (modification of an immutable value) *)
-  let lzv = Sys.opaque_identity lzv in
-  let x = Obj.repr lzv in
-  let t = Obj.tag x in
-  if t = Obj.forward_tag then (Obj.obj (Obj.field x 0) : 'arg) else
-  if t <> Obj.lazy_tag then (Obj.obj x : 'arg)
-  else force_lazy_block lzv
-
-
-let force_val (lzv : 'arg lazy_t) =
-  let x = Obj.repr lzv in
-  let t = Obj.tag x in
-  if t = Obj.forward_tag then (Obj.obj (Obj.field x 0) : 'arg) else
-  if t <> Obj.lazy_tag then (Obj.obj x : 'arg)
-  else force_val_lazy_block lzv
+let force_val (type a) (lzv : a lazy_t) : a =
+  let lzv : _ concrete = castToConcrete lzv in
+  if lzv.tag then lzv.value  else
+    force_val_lazy_block (of_concrete lzv)

--- a/jscomp/stdlib-412/stdlib_modules/camlinternalLazy.mli
+++ b/jscomp/stdlib-412/stdlib_modules/camlinternalLazy.mli
@@ -27,3 +27,6 @@ val force_val_lazy_block : 'a lazy_t -> 'a
 
 val force : 'a lazy_t -> 'a
 val force_val : 'a lazy_t -> 'a
+
+val is_val : 'a lazy_t -> bool
+

--- a/jscomp/stdlib-412/stdlib_modules/hashtbl.ml
+++ b/jscomp/stdlib-412/stdlib_modules/hashtbl.ml
@@ -38,8 +38,7 @@ and ('a, 'b) bucketlist =
 *)
 
 let ongoing_traversal h =
-  Obj.size (Obj.repr h) < 4 (* compatibility with old hash tables *)
-  || h.initial_size < 0
+  h.initial_size < 0
 
 let flip_ongoing_traversal h =
   h.initial_size <- - h.initial_size
@@ -90,8 +89,7 @@ let clear h =
 
 let reset h =
   let len = Array.length h.data in
-  if Obj.size (Obj.repr h) < 4 (* compatibility with old hash tables *)
-    || len = abs h.initial_size then
+  if len = abs h.initial_size then
     clear h
   else begin
     h.size <- 0;
@@ -511,9 +509,7 @@ let hash_param n1 n2 x = seeded_hash_param n1 n2 0 x
 let seeded_hash seed x = seeded_hash_param 10 100 seed x
 
 let key_index h key =
-  if Obj.size (Obj.repr h) >= 4
-  then (seeded_hash_param 10 100 h.seed key) land (Array.length h.data - 1)
-  else invalid_arg "Hashtbl: unsupported hash table format"
+  (seeded_hash_param 10 100 h.seed key) land (Array.length h.data - 1)
 
 let add h key data =
   let i = key_index h key in
@@ -629,13 +625,13 @@ let rebuild ?(random = !randomized) h =
   let s = power_2_above 16 (Array.length h.data) in
   let seed =
     if random then Random.State.bits (Lazy.force prng)
-    else if Obj.size (Obj.repr h) >= 4 then h.seed
-    else 0 in
+    else h.seed
+  in
   let h' = {
     size = h.size;
     data = Array.make s Empty;
     seed = seed;
-    initial_size = if Obj.size (Obj.repr h) >= 4 then h.initial_size else s
+    initial_size = h.initial_size
   } in
   insert_all_buckets (key_index h') false h.data h'.data;
   h'

--- a/jscomp/stdlib-412/stdlib_modules/lazy.ml
+++ b/jscomp/stdlib-412/stdlib_modules/lazy.ml
@@ -51,7 +51,7 @@ type 'a t = 'a CamlinternalLazy.t
 
 exception Undefined = CamlinternalLazy.Undefined
 
-external make_forward : 'a -> 'a lazy_t = "caml_lazy_make_forward"
+(* external make_forward : 'a -> 'a lazy_t = "caml_lazy_make_forward" *)
 
 external force : 'a t -> 'a = "%lazy_force"
 
@@ -59,22 +59,11 @@ external force : 'a t -> 'a = "%lazy_force"
 
 let force_val = CamlinternalLazy.force_val
 
-let from_fun (f : unit -> 'arg) =
-  let x = Obj.new_block Obj.lazy_tag 1 in
-  Obj.set_field x 0 (Obj.repr f);
-  (Obj.obj x : 'arg t)
+let from_fun f = lazy (f ())
 
+let from_val v = lazy v
 
-let from_val (v : 'arg) =
-  let t = Obj.tag (Obj.repr v) in
-  if t = Obj.forward_tag || t = Obj.lazy_tag || t = Obj.double_tag then begin
-    make_forward v
-  end else begin
-    (Obj.magic v : 'arg t)
-  end
-
-
-let is_val (l : 'arg t) = Obj.tag (Obj.repr l) <> Obj.lazy_tag
+let is_val = CamlinternalLazy.is_val
 
 let lazy_from_fun = from_fun
 

--- a/jscomp/stdlib-412/stdlib_modules/obj.ml
+++ b/jscomp/stdlib-412/stdlib_modules/obj.ml
@@ -40,7 +40,6 @@ external raw_field : t -> int -> raw_data = "caml_obj_raw_field"
 external set_raw_field : t -> int -> raw_data -> unit
                                           = "caml_obj_set_raw_field"
 
-external new_block : int -> int -> t = "caml_obj_block"
 external dup : t -> t = "caml_obj_dup"
 external truncate : t -> int -> unit = "caml_obj_truncate"
 external add_offset : t -> Int32.t -> t = "caml_obj_add_offset"

--- a/jscomp/stdlib-412/stdlib_modules/obj.mli
+++ b/jscomp/stdlib-412/stdlib_modules/obj.mli
@@ -70,7 +70,6 @@ external set_raw_field : t -> int -> raw_data -> unit
                                           = "caml_obj_set_raw_field"
   (* @since 4.12 *)
 
-external new_block : int -> int -> t = "caml_obj_block"
 external dup : t -> t = "caml_obj_dup"
 external truncate : t -> int -> unit = "caml_obj_truncate"
   [@@ocaml.deprecated]

--- a/jscomp/stdlib-412/stdlib_modules/pervasives.ml
+++ b/jscomp/stdlib-412/stdlib_modules/pervasives.ml
@@ -224,8 +224,8 @@ let set_binary_mode_in = set_binary_mode_in
 module LargeFile = LargeFile
 type nonrec 'a ref = 'a ref = { mutable contents : 'a }
 external ref : 'a -> 'a ref = "%makemutable"
-external ( ! ) : 'a ref -> 'a = "%field0"
-external ( := ) : 'a ref -> 'a -> unit = "%setfield0"
+external ( ! ) : 'a ref -> 'a = "%bs_ref_field0"
+external ( := ) : 'a ref -> 'a -> unit = "%bs_ref_setfield0"
 external incr : int ref -> unit = "%incr"
 external decr : int ref -> unit = "%decr"
 type nonrec ('a,'b) result = ('a,'b) result = Ok of 'a | Error of 'b

--- a/jscomp/stdlib-412/stdlib_modules/printexc.ml
+++ b/jscomp/stdlib-412/stdlib_modules/printexc.ml
@@ -21,27 +21,23 @@ let printers = Atomic.make []
 
 let locfmt = format_of_string "File \"%s\", line %d, characters %d-%d: %s"
 
-let field x i =
-  let f = Obj.field x i in
-  if not (Obj.is_block f) then
-    sprintf "%d" (Obj.magic f : int)           (* can also be a char *)
-  else if Obj.tag f = Obj.string_tag then
-    sprintf "%S" (Obj.magic f : string)
-  else if Obj.tag f = Obj.double_tag then
-    string_of_float (Obj.magic f : float)
-  else
-    "_"
+let fields : exn -> string = [%raw{|function(x){
+  var s = ""
+  var index = 1
+  while ("_"+index in x){
+    s += x ["_" + index];
+    ++ index
+  }
+  if(index === 1){
+    return s
+  }
+  return "(" + s + ")"
+}
+|}]
 
-let rec other_fields x i =
-  if i >= Obj.size x then ""
-  else sprintf ", %s%s" (field x i) (other_fields x (i+1))
+external exn_slot_id :  exn -> int  = "caml_exn_slot_id"
 
-let fields x =
-  match Obj.size x with
-  | 0 -> ""
-  | 1 -> ""
-  | 2 -> sprintf "(%s)" (field x 1)
-  | _ -> sprintf "(%s%s)" (field x 1) (other_fields x 2)
+external exn_slot_name : exn -> string = "caml_exn_slot_name"
 
 let use_printers x =
   let rec conv = function
@@ -62,13 +58,8 @@ let to_string_default = function
   | Undefined_recursive_module(file, line, char) ->
       sprintf locfmt file line char (char+6) "Undefined recursive module"
   | x ->
-      let x = Obj.repr x in
-      if Obj.tag x <> 0 then
-        (Obj.magic (Obj.field x 0) : string)
-      else
-        let constructor =
-          (Obj.magic (Obj.field (Obj.field x 0) 0) : string) in
-        constructor ^ (fields x)
+      let constructor = exn_slot_name x in
+      constructor ^ fields  x
 
 let to_string e =
   match use_printers e with
@@ -278,18 +269,6 @@ let rec register_printer fn =
   if not success then register_printer fn
 
 external get_callstack: int -> raw_backtrace = "caml_get_current_callstack"
-
-let exn_slot x =
-  let x = Obj.repr x in
-  if Obj.tag x = 0 then Obj.field x 0 else x
-
-let exn_slot_id x =
-  let slot = exn_slot x in
-  (Obj.obj (Obj.field slot 1) : int)
-
-let exn_slot_name x =
-  let slot = exn_slot x in
-  (Obj.obj (Obj.field slot 0) : string)
 
 external get_debug_info_status : unit -> int = "caml_ml_debug_info_status"
 

--- a/jscomp/stdlib-412/stdlib_modules/stdlib__no_aliases.ml
+++ b/jscomp/stdlib-412/stdlib_modules/stdlib__no_aliases.ml
@@ -312,8 +312,8 @@ external snd : 'a * 'b -> 'b = "%field1"
 
 type 'a ref = { mutable contents : 'a }
 external ref : 'a -> 'a ref = "%makemutable"
-external ( ! ) : 'a ref -> 'a = "%field0"
-external ( := ) : 'a ref -> 'a -> unit = "%setfield0"
+external ( ! ) : 'a ref -> 'a = "%bs_ref_field0"
+external ( := ) : 'a ref -> 'a -> unit = "%bs_ref_setfield0"
 external incr : int ref -> unit = "%incr"
 external decr : int ref -> unit = "%decr"
 

--- a/jscomp/stdlib-412/stdlib_modules/sys.ml
+++ b/jscomp/stdlib-412/stdlib_modules/sys.ml
@@ -25,10 +25,7 @@ type backend_type =
 (* System interface *)
 
 (* external get_config: unit -> string * int * bool = "caml_sys_get_config" *)
-#if BS then
-#else
 external get_executable_name : unit -> string = "caml_sys_executable_name"
-#end
 external argv : string array = "%sys_argv"
 external big_endian : unit -> bool = "%big_endian"
 external word_size : unit -> int = "%word_size"
@@ -39,10 +36,7 @@ external win32 : unit -> bool = "%ostype_win32"
 external cygwin : unit -> bool = "%ostype_cygwin"
 external get_backend_type : unit -> backend_type = "%backend_type"
 
-#if BS then
-#else
 let executable_name = get_executable_name()
-#end
 
 #if BS then
 external get_os_type : unit -> string = "#os_type"

--- a/jscomp/stdlib-412/stdlib_modules/sys.mli
+++ b/jscomp/stdlib-412/stdlib_modules/sys.mli
@@ -26,14 +26,11 @@ external argv : string array = "%sys_argv"
    The following elements are the command-line arguments
    given to the program. *)
 
-#if BS then
-#else
 val executable_name : string
 (** The name of the file containing the executable currently running.
     This name may be absolute or relative to the current directory, depending
     on the platform and whether the program was compiled to bytecode or a native
     executable. *)
-#end
 
 external file_exists : string -> bool = "caml_sys_file_exists"
 (** Test if a file with the given name exists. *)


### PR DESCRIPTION
Fixes the runtime for the following features / modules

- `Sys`
- refs
- `Lazy`
- OCaml classes
- `Hashtbl`
- `Printexc`