### PR TITLE
Fix incorrect inlining of match .. with | exception .. in non-tail position

### DIFF
--- a/jscomp/core/lam_exit_count.mli
+++ b/jscomp/core/lam_exit_count.mli
@@ -23,11 +23,16 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
 
- type collection 
+type exit = {
+  mutable count: int;
+  mutable max_depth: int;
+}
 
- 
- val count_helper : Lam.t -> collection
+type collection = (int, exit) Hashtbl.t
 
- val count_exit : collection -> int -> int 
+val count_helper : try_depth:int ref -> Lam.t -> collection
+
+val get_exit : collection -> int -> exit
+
 
 


### PR DESCRIPTION
When getting the runtime tests to run, one of the more puzzling failures was one related to inlining of expressions within `match ... with | exception ...`.

- The test correspods to https://github.com/ocsigen/js_of_ocaml/issues/400
- In upstream OCaml, it was tracked in https://github.com/ocaml/ocaml/issues/7680, and fixed in https://github.com/ocaml/ocaml/pull/1497

This patch is an attempt at an almost direct port of the aforementioned PR to OCaml to work within this codebase.