### PR TITLE
Only generate the `dune.bsb` file if `-make-world` is passed

### DIFF
--- a/jscomp/bsb/bsb_world.ml
+++ b/jscomp/bsb/bsb_world.ml
@@ -79,7 +79,7 @@ let build_bs_deps cwd ~buf ~pinned_dependencies (deps : Bsb_package_specs.t) =
 
 
 
-let make_world_deps cwd ~buf (config : Bsb_config_types.t option) =
+let make_world_deps ~cwd ~buf (config : Bsb_config_types.t option) =
   Bsb_log.info "Making the dependency world!@.";
   let deps, pinned_dependencies =
     match config with

--- a/jscomp/bsb/bsb_world.mli
+++ b/jscomp/bsb/bsb_world.mli
@@ -26,7 +26,7 @@ val install_targets:
   string -> Bsb_config_types.t -> unit
 
 val make_world_deps:
-  string ->
+  cwd:string ->
   buf: Buffer.t ->
   Bsb_config_types.t option ->
   unit


### PR DESCRIPTION
The previous behavior of generating a dune file containing rules for
only the toplevel project is not a good default if `bsb` is now
effectively just a frontend to dune.


fixes #40 