### PR TITLE
Don't issue warning 34 (unused type) for `bs.deriving abstract`

### DIFF
--- a/jscomp/frontend/ast_tdcls.ml
+++ b/jscomp/frontend/ast_tdcls.ml
@@ -45,7 +45,7 @@ let newTdcls
 
 let disable_unused_type: Parsetree.attribute =
   { attr_name = Location.mknoloc "ocaml.warning";
-    attr_payload = PStr [ Str.eval (Exp.constant (Pconst_string ("-34", Location.none, None))) ];
+    attr_payload = PStr [ Str.eval (Exp.constant (Pconst_string ("-unused-type-declaration", Location.none, None))) ];
     attr_loc = Location.none
   }
 
@@ -131,5 +131,4 @@ let handleTdclsInStru
   | {bs_deriving = None }, _  ->
     Bs_ast_mapper.default_mapper.structure_item self str
   end
-
 

--- a/jscomp/frontend/ast_tdcls.ml
+++ b/jscomp/frontend/ast_tdcls.ml
@@ -43,6 +43,11 @@ let newTdcls
              Parsetree.ptype_attributes = newAttrs}
          else x )
 
+let disable_unused_type: Parsetree.attribute =
+  { attr_name = Location.mknoloc "ocaml.warning";
+    attr_payload = PStr [ Str.eval (Exp.constant (Pconst_string ("-34", Location.none, None))) ];
+    attr_loc = Location.none
+  }
 
 let handleTdclsInSigi
     (self : Bs_ast_mapper.mapper)
@@ -55,7 +60,7 @@ let handleTdclsInSigi
   | {bs_deriving = Some actions}, newAttrs
     ->
     let loc = sigi.psig_loc in
-    let originalTdclsNewAttrs = newTdcls tdcls newAttrs in (* remove the processed attr*)
+    let originalTdclsNewAttrs = newTdcls tdcls (disable_unused_type :: newAttrs) in (* remove the processed attr*)
     let newTdclsNewAttrs = self.type_declaration_list self originalTdclsNewAttrs in
     let kind = Ast_derive_abstract.isAbstract actions in
     if kind <> Not_abstract then
@@ -86,7 +91,6 @@ let handleTdclsInSigi
 
   end
 
-
 let handleTdclsInStru
     (self : Bs_ast_mapper.mapper)
     (str : Parsetree.structure_item)
@@ -99,7 +103,7 @@ let handleTdclsInStru
   | {bs_deriving = Some actions;
     }, newAttrs ->
     let loc = str.pstr_loc in
-    let originalTdclsNewAttrs = newTdcls tdcls newAttrs in
+    let originalTdclsNewAttrs = newTdcls tdcls (disable_unused_type :: newAttrs) in
     let newStr : Parsetree.structure_item =
       Ast_compatible.rec_type_str ~loc rf (self.type_declaration_list self originalTdclsNewAttrs)
     in

--- a/jscomp/test/bs_abstract_test.ml
+++ b/jscomp/test/bs_abstract_test.ml
@@ -1,19 +1,19 @@
+[@@@config {flags = [|"-w";"+34";"-warn-error"; "A"|]}]
 
-
-type 'a linked_list = 
+type 'a linked_list =
   {
-    hd : 'a ; 
+    hd : 'a ;
     mutable tl : 'a linked_list Js.null
   }
   [@@bs.deriving abstract]
 
 
 
-let v = linked_list ~hd:3 ~tl:Js.null   
+let v = linked_list ~hd:3 ~tl:Js.null
 
 ;; tlSet v (Js.Null.return v)
 
-type t = int -> int -> bool [@bs]
+type[@warning "-34"] t = int -> int -> bool [@bs]
 and x = {
   k : t;
   y : string
@@ -26,42 +26,42 @@ let x1 k = x ~k ~y:"xx"
 let f = x ~k:(fun[@bs] x y -> x = y) ~y:"x"
 
 type u = {
-  x : int ; 
+  x : int ;
   y0 : int -> int;
-  y1 : int -> int -> int 
+  y1 : int -> int -> int
 } [@@bs.deriving abstract]
 
 
-let uf u =  u |. y0Get 1 
-let uf1 u = u |. y1Get 1 
+let uf u =  u |. y0Get 1
+let uf1 u = u |. y1Get 1
 let uf2 u = u |. y1Get 1 2
 
 type u1 = {
-  x : int; 
+  x : int;
   yyyy : (int -> int [@bs]);
   yyyy1 : (int -> int -> int  [@bs]);
   yyyy2 : int -> int  [@bs.optional]
 } [@@bs.deriving abstract]
 
-let uff f = 
+let uff f =
   (f |. yyyyGet) 1 [@bs]
 
-let uff2 f =   
+let uff2 f =
   (f |. yyyy1Get) 1 2 [@bs]
 
-let uff3 f =   
-  match f |. yyyy2Get with 
+let uff3 f =
+  match f |. yyyy2Get with
   | None -> 0
-  | Some x  -> x 0 
+  | Some x  -> x 0
 
 
 
 type u3 = {
-  x : int; 
+  x : int;
   yyyy : (int -> int [@bs]);
   yyyy1 : (int -> int -> int  [@bs]);
   yyyy2 : int -> int  [@bs.optional]
 } [@@bs.deriving { abstract = light} ]
 
 
-let fx v = v |. x 
+let fx v = v |. x

--- a/jscomp/test/bs_abstract_test.ml
+++ b/jscomp/test/bs_abstract_test.ml
@@ -1,4 +1,4 @@
-[@@@config {flags = [|"-w";"+34";"-warn-error"; "A"|]}]
+[@@@config {flags = [|"-w";"+unused-type-declaration";"-warn-error"; "A"|]}]
 
 type 'a linked_list =
   {
@@ -13,7 +13,7 @@ let v = linked_list ~hd:3 ~tl:Js.null
 
 ;; tlSet v (Js.Null.return v)
 
-type[@warning "-34"] t = int -> int -> bool [@bs]
+type[@warning "-unused-type-declaration"] t = int -> int -> bool [@bs]
 and x = {
   k : t;
   y : string


### PR DESCRIPTION
The code generated by `bs.deriving abstract` makes the target type abstract. It achieves that by generating code that looks e.g. like the following:

```ocaml
include (struct
  type t = {
    x: string
  }
end : sig  end)

type t
```

The warning is correct in the sense that the type effectively becomes unused. OCaml 4.12 started detecting cases like this, so the fix is to just turn it off for the original type.

### Test plan

- Turned on `warn-error` for warning 34 in the existing test for `bs.deriving abstract` and verified:
  - test fails to compile before this fix
  - test compiles fine after the fix


fixes #28 

cc @thespyder