### PR TITLE
Generators: don't call basename on inputs

### DIFF
--- a/jscomp/bsb/bsb_ninja_file_groups.ml
+++ b/jscomp/bsb/bsb_ninja_file_groups.ml
@@ -30,20 +30,15 @@ let (//) = Ext_path.combine
 let handle_generators buf
     (group : Bsb_file_groups.file_group)
     custom_rules =
-  let map_to_source_dir =
-    (fun x -> Bsb_config.proj_rel (group.dir //x )) in
   Ext_list.iter group.generators (fun {output; input; command} ->
-      (*TODO: add a loc for better error message *)
+      (* TODO: add a loc for better error message *)
       match Map_string.find_opt custom_rules command with
       | None -> Ext_fmt.failwithf ~loc:__LOC__ "custom rule %s used but  not defined" command
       | Some rule ->
         Bsb_ninja_targets.output_build group.dir buf
-          ~outputs:(Ext_list.map  output  map_to_source_dir)
-          ~inputs:(Ext_list.map input map_to_source_dir)
-          ~rule
-    )
-
-
+          ~outputs:output
+          ~inputs:input
+          ~rule)
 
 
 type suffixes = {

--- a/jscomp/bsb/bsb_ninja_file_groups.ml
+++ b/jscomp/bsb/bsb_ninja_file_groups.ml
@@ -22,10 +22,8 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
+let basename = Filename.basename
 let (//) = Ext_path.combine
-
-
-
 
 
 
@@ -93,7 +91,7 @@ let emit_module_build
   let output_ast = filename_sans_extension  ^ Literals.suffix_ast in
   let output_iast = filename_sans_extension  ^ Literals.suffix_iast in
   let output_d = filename_sans_extension ^ Literals.suffix_d in
-  let output_d_as_dep = Format.asprintf "(:dep_file %s)" (Filename.basename output_d) in
+  let output_d_as_dep = Format.asprintf "(:dep_file %s)" (basename output_d) in
   let output_filename_sans_extension =
       Ext_namespace_encode.make ?ns:namespace filename_sans_extension
   in
@@ -103,13 +101,13 @@ let emit_module_build
     Bsb_package_specs.get_list_of_output_js package_specs output_filename_sans_extension in
   Bsb_ninja_targets.output_build cur_dir buf
     ~outputs:[output_ast]
-    ~inputs:[input_impl]
+    ~inputs:[basename input_impl]
     ~rule:ast_rule;
   Bsb_ninja_targets.output_build
     cur_dir
     buf
     ~outputs:[output_d]
-    ~inputs:(if has_intf_file then [output_ast;output_iast] else [output_ast] )
+    ~inputs:(Ext_list.map (if has_intf_file then [output_ast;output_iast] else [output_ast] ) basename)
     ~rule:(if is_dev then rules.build_bin_deps_dev else rules.build_bin_deps)
   ;
   let relative_ns_cmi =
@@ -147,13 +145,13 @@ let emit_module_build
       (* TODO: we can get rid of absloute path if we fixed the location to be
           [lib/bs], better for testing?
       *)
-      ~inputs:[input_intf]
+      ~inputs:[basename input_intf]
       ~rule:ast_rule
     ;
     Bsb_ninja_targets.output_build cur_dir buf
       ~implicit_deps:[output_d_as_dep]
       ~outputs:[output_cmi]
-      ~inputs:[output_iast]
+      ~inputs:[basename output_iast]
       ~rule:(if is_dev then rules.mi_dev else rules.mi)
       ~bs_dependencies
       ~rel_deps:(rel_bs_config_json :: relative_ns_cmi)
@@ -174,8 +172,8 @@ let emit_module_build
     ~implicit_outputs:
      (if has_intf_file then [] else [ output_cmi ])
     ~js_outputs:output_js
-    ~inputs:[output_ast]
-    ~implicit_deps:(if has_intf_file then [(Filename.basename output_cmi); output_d_as_dep] else [output_d_as_dep])
+    ~inputs:[basename output_ast]
+    ~implicit_deps:(if has_intf_file then [(basename output_cmi); output_d_as_dep] else [output_d_as_dep])
     ~bs_dependencies
     ~rel_deps:(rel_bs_config_json :: relative_ns_cmi)
     ~rule;

--- a/jscomp/bsb/bsb_ninja_targets.ml
+++ b/jscomp/bsb/bsb_ninja_targets.ml
@@ -188,7 +188,7 @@ let output_build
   Buffer.add_string buf "(deps (:inputs ";
   Ext_list.iter inputs (fun s ->
     Buffer.add_string buf Ext_string.single_space;
-    Buffer.add_string buf (Filename.basename s));
+    Buffer.add_string buf s);
   Buffer.add_string buf ") ";
   if implicit_deps <> [] then begin
       Ext_list.iter implicit_deps (fun s ->


### PR DESCRIPTION
There are two changes in the PR:

1. 72d7054 stops calling `Filename.basename` in the rule generation by default
2. 67900f6 is the real fix. it makes sure to not mess with the path that the user wrote in `bsconfig.json`
    - in the future we should probably assert that this is a relative path, though dune might take care of that for us now.

bug reported by @jchavarri