### PR TITLE
Don't add a dependency on directories without targets

### DIFF
--- a/jscomp/bsb/bsb_config_parse.ml
+++ b/jscomp/bsb/bsb_config_parse.ml
@@ -406,13 +406,14 @@ and extract_dependencies ~package_kind (map : json_map) cwd (field : string )
      let ns_incl = Ext_option.map namespace (fun _ns ->
        dep.package_install_path // Bsb_config.lib_bs)
      in
-     let dirs = Ext_list.filter_map files (fun { Bsb_file_groups.dir; is_dev; _ } ->
-        if not is_dev then Some (dep.package_path // dir) else None
-     )
+     let dirs = Ext_list.filter_map files (fun ({ Bsb_file_groups.dir; is_dev; _ } as group) ->
+        if not is_dev && not (Bsb_file_groups.is_empty group) then
+          Some (dep.package_path // dir)
+        else
+          None)
      in
      let install_dirs = Ext_list.filter_map files (fun { Bsb_file_groups.dir; is_dev; _ } ->
-        if not is_dev then Some (dep.package_install_path // dir) else None
-     )
+        if not is_dev then Some (dep.package_install_path // dir) else None)
      in
      { dep with
        package_install_dirs = (match ns_incl with Some ns_incl -> ns_incl :: install_dirs | None -> install_dirs);

--- a/jscomp/bsb/bsb_ninja_gen.ml
+++ b/jscomp/bsb/bsb_ninja_gen.ml
@@ -29,10 +29,10 @@ let (//) = Ext_path.combine
 *)
 
 
-
-
 (* let dash_i = "-I" *)
 
+let dependencies_directories ~file_groups deps =
+  Ext_list.flat_map deps (fun { Bsb_config_types.package_dirs; _ } -> package_dirs)
 
 
 let get_bsc_flags
@@ -252,10 +252,10 @@ let output_ninja_and_namespace_map
       ~package_specs
       generators in
   let bs_dependencies =
-   Ext_list.flat_map bs_dependencies (fun { Bsb_config_types.package_dirs; _ } -> package_dirs)
+    dependencies_directories ~file_groups:bs_file_groups bs_dependencies
   in
   let bs_dev_dependencies =
-   Ext_list.flat_map bs_dev_dependencies (fun { Bsb_config_types.package_dirs; _ } -> package_dirs)
+    dependencies_directories ~file_groups:bs_file_groups bs_dev_dependencies
   in
   Buffer.add_char buf '\n';
 


### PR DESCRIPTION
- directories that don't have targets were still generating an empty alias, which dune doesn't seem to like

The error was exposed to the user as:

```
Error: No rule found for alias
node_modules/rescript-apollo-client/src/@apollo/client/errors/__tests__/bsb_world
```

Reported by @jfrolich