### PR TITLE
Don't assume some types can be unnested just by the impl type

### DIFF
--- a/jscomp/frontend/ast_external_process.ml
+++ b/jscomp/frontend/ast_external_process.ml
@@ -492,12 +492,12 @@ let process_obj
                    param_type::arg_types, result_types
                  | Nothing ->
                    let s = (Lam_methname.translate  name) in
-                   let for_sure_not_nested =
-                     match ty.ptyp_desc with
-                     | Ptyp_constr({txt = Lident txt;_}, []) ->
-                       Ast_core_type.is_builtin_rank0_type txt
-                     | _ -> false in
-                   {obj_arg_label = External_arg_spec.optional for_sure_not_nested s; obj_arg_type},
+                   (* XXX(anmonteiro): it's unsafe to just read the type of the
+                      labelled argument declaration, since it could be `'a` in
+                      the implementation, and e.g. `bool` in the interface. See
+                      https://github.com/anmonteiro/bucklescript/pull/58 for
+                      a test case. *)
+                   {obj_arg_label = External_arg_spec.optional false s; obj_arg_type},
                    param_type :: arg_types,
                    Ast_compatible.object_field {Asttypes.txt = name; loc} [] (Ast_comb.to_undefined_type loc ty) ::  result_types
                  | Int _  ->

--- a/jscomp/test/dune.gen
+++ b/jscomp/test/dune.gen
@@ -2262,6 +2262,32 @@
 
 
   (rule
+    (targets external_intf_impl.cmj external_intf_impl.js)
+    (deps (:inputs external_intf_impl.ml) ../stdlib-412/stdlib.cmj external_intf_impl.cmi)
+
+  (mode
+   (promote
+    (until-clean)
+    (only external_intf_impl.js)))
+
+    (action
+     (run bsc -bs-read-cmi -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-60-67-68-106+104 -warn-error A  -I ../runtime -I ../stdlib-412/stdlib_modules -nopervasives -open Stdlib__no_aliases -I ../others -I . %{inputs})))
+
+
+  (rule
+    (targets external_intf_impl.cmi )
+    (deps (:inputs external_intf_impl.mli) ../stdlib-412/stdlib.cmj)
+
+  (mode
+   (promote
+    (until-clean)
+    (only )))
+
+    (action
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-60-67-68-106+104 -warn-error A  -I ../runtime -I ../stdlib-412/stdlib_modules -nopervasives -open Stdlib__no_aliases -I ../others -I . %{inputs})))
+
+
+  (rule
     (targets external_polyfill_test.cmi external_polyfill_test.cmj external_polyfill_test.js)
     (deps (:inputs external_polyfill_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 

--- a/jscomp/test/external_intf_impl.js
+++ b/jscomp/test/external_intf_impl.js
@@ -1,0 +1,1 @@
+/* This output is empty. Its source's type definitions, externals and/or unused code got optimized away. */

--- a/jscomp/test/external_intf_impl.ml
+++ b/jscomp/test/external_intf_impl.ml
@@ -1,0 +1,4 @@
+
+external makeProps :
+  ?primary:'primary ->
+    ?key:string -> unit -> < primary: 'primary option   >  Js.t = ""[@@bs.obj]

--- a/jscomp/test/external_intf_impl.mli
+++ b/jscomp/test/external_intf_impl.mli
@@ -1,0 +1,4 @@
+
+external makeProps :
+  ?primary:bool ->
+    ?key:string -> unit -> < primary: bool option   >  Js.t = ""[@@bs.obj ]


### PR DESCRIPTION
In e.g. a `[@bs.obj] external ...` context, assuming too much can lead to type errors. Here's an example:

```ocaml
(* x.mli *)
external x :
  ?primary:bool -> unit -> < primary: bool option   >  Js.t = ""[@@bs.obj ]

(* x.ml *)
external makeProps :
  ?primary:'primary -> unit -> < primary: 'primary option   >  Js.t = ""[@@bs.obj]
```

In this case, the type-directed optimization assumed different types and caused a type mismatch.