### PR TITLE
napkin: revert the rest of upstream PR#291

### DIFF
--- a/jscomp/napkin/res_ast_conversion.ml
+++ b/jscomp/napkin/res_ast_conversion.ml
@@ -359,14 +359,6 @@ let normalize =
       | _ ->
         default_mapper.pat mapper p
     end;
-    typ = (fun mapper typ ->
-      match typ.ptyp_desc with
-      | Ptyp_constr({txt = Longident.Ldot(Longident.Lident "Js", "t")}, [arg]) ->
-        (* Js.t({"a": b}) -> {"a": b}
-          Since compiler >9.0.1 objects don't need Js.t wrapping anymore *)
-         mapper.typ mapper arg
-      | _ -> default_mapper.typ mapper typ
-    );
     expr = (fun mapper expr ->
       match expr.pexp_desc with
       | Pexp_constant (Pconst_string (txt, None)) ->

--- a/jscomp/napkin/res_core.ml
+++ b/jscomp/napkin/res_core.ml
@@ -375,6 +375,15 @@ let makeListPattern loc seq ext_opt =
       Ast_helper.Pat.mk ~loc (Ppat_construct(Location.mkloc (Longident.Lident "::") loc, Some arg))
   in
   handle_seq seq
+(* {"foo": bar} -> Js.t({. foo: bar})
+ * {.. "foo": bar} -> Js.t({.. foo: bar})
+ * {..} -> Js.t({..}) *)
+let makeBsObjType ~attrs ~loc ~closed rows =
+  let obj = Ast_helper.Typ.object_ ~loc rows closed in
+  let jsDotTCtor =
+    Location.mkloc (Longident.Ldot (Longident.Lident "Js", "t")) loc
+  in
+  Ast_helper.Typ.constr ~loc ~attrs jsDotTCtor [obj]
 
 (* TODO: diagnostic reporting *)
 let lidentOfPath longident =
@@ -3806,7 +3815,7 @@ and parseRecordOrBsObjectType ~attrs p =
   in
   Parser.expect Rbrace p;
   let loc = mkLoc startPos p.prevEndPos in
-  Ast_helper.Typ.object_ ~loc ~attrs fields closedFlag
+  makeBsObjType ~attrs ~loc ~closed:closedFlag fields
 
 (* TODO: check associativity in combination with attributes *)
 and parseTypeAlias p typ =
@@ -4208,7 +4217,7 @@ and parseConstrDeclArgs p =
         in
         Parser.expect Rbrace p;
         let loc = mkLoc startPos p.prevEndPos in
-        let typ = Ast_helper.Typ.object_ ~loc ~attrs:[] fields closedFlag in
+        let typ = makeBsObjType ~attrs:[] ~loc ~closed:closedFlag fields in
         Parser.optional p Comma |> ignore;
         let moreArgs =
           parseCommaDelimitedRegion
@@ -4259,7 +4268,7 @@ and parseConstrDeclArgs p =
             ) in
             Parser.expect Rbrace p;
             let loc = mkLoc startPos p.prevEndPos in
-            let typ = Ast_helper.Typ.object_ ~loc ~attrs:[] fields closedFlag in
+            let typ = makeBsObjType ~attrs:[]  ~loc ~closed:closedFlag fields in
             Parser.optional p Comma |> ignore;
             let moreArgs =
               parseCommaDelimitedRegion
@@ -4591,7 +4600,7 @@ and parseRecordOrBsObjectDecl p =
     Parser.expect Rbrace p;
     let loc = mkLoc startPos p.prevEndPos in
     let typ =
-      Ast_helper.Typ.object_ ~loc ~attrs:[] fields closedFlag
+      makeBsObjType ~attrs:[] ~loc ~closed:closedFlag fields
       |> parseTypeAlias p
     in
     let typ = parseArrowTypeRest ~es6Arrow:true ~startPos typ p in
@@ -4638,7 +4647,7 @@ and parseRecordOrBsObjectDecl p =
         Parser.expect Rbrace p;
         let loc = mkLoc startPos p.prevEndPos in
         let typ =
-          Ast_helper.Typ.object_ ~loc ~attrs:[] fields closedFlag |> parseTypeAlias p
+          makeBsObjType ~attrs:[] ~loc ~closed:closedFlag fields |> parseTypeAlias p
         in
         let typ = parseArrowTypeRest ~es6Arrow:true ~startPos typ p in
         (Some typ, Asttypes.Public, Parsetree.Ptype_abstract)


### PR DESCRIPTION
- Revert the rest of https://github.com/rescript-lang/syntax/pull/291
  - we had previously reverted the JSX PPX portions, but it's important to revert the rest of the PR too, for folks that want to keep using ReScript syntax with this project.