### PR TITLE
ci: add macOS ARM64

### DIFF
--- a/.github/workflows/esy-build.yml
+++ b/.github/workflows/esy-build.yml
@@ -28,5 +28,11 @@ jobs:
         run: npm install -g esy
 
       - uses: esy/github-action@master
+        if: ${{ matrix.system != 'macos-arm64' }}
+        with:
+          cache-key: ${{ hashFiles('esy.lock/index.json') }}
+
+      - uses: EduardoRFS/github-action@0e5336e318d2f648cf881ab85ece10f51e369b17
+        if: ${{ matrix.system == 'macos-arm64' }}
         with:
           cache-key: ${{ hashFiles('esy.lock/index.json') }}

--- a/.github/workflows/esy-build.yml
+++ b/.github/workflows/esy-build.yml
@@ -3,8 +3,8 @@ name: Build using esy
 on:
   pull_request:
   push:
-   branches:
-     - fork
+    branches:
+      - fork
 
 jobs:
   build:
@@ -12,17 +12,19 @@ jobs:
 
     strategy:
       matrix:
-        system: [windows-latest, ubuntu-latest, macos-latest]
+        system: [windows, ubuntu, macos, macos-arm64]
 
-    runs-on: ${{ matrix.system }}
+    runs-on: ${{ matrix.system }}-latest
 
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
+        if: ${{ matrix.system != 'macos-arm64' }}
         with:
           node-version: 14
 
       - name: Install esy
+        if: ${{ matrix.system != 'macos-arm64' }}
         run: npm install -g esy
 
       - uses: esy/github-action@master


### PR DESCRIPTION
This use our new self-hosted Mac Mini M1 as a way to ensure bucklescript is running on macOS ARM64

## Temporary

This solution is temporary, while https://github.com/actions/virtual-environments/issues/2187 is not solved