### PR TITLE
Turn off warning 29 by default

### DIFF
--- a/jscomp/ext/bsc_warnings.ml
+++ b/jscomp/ext/bsc_warnings.ml
@@ -57,21 +57,21 @@
   only in some special cases that we need all fields being listed
 
   We encourage people to write code based on type based disambigution
-  40,41,42 are enabled for compatiblity reasons  
+  40,41,42 are enabled for compatiblity reasons
   -40 Constructor or label name used out of scope
   This is intentional, we should never warn it
   - 41 Ambiguous constructor or label name.
   It is turned off since it prevents such cases below:
   {[
-    type a = A |B 
+    type a = A |B
     type b = A | B | C
   ]}
   - 42 Disambiguated constructor or label name (compatibility warning).
-  
+
   - 50 Unexpected documentation comment.
 
   - 102 Bs_polymorphic_comparison
 *)
-let defaults_w = "+a-4-9-20-40-41-42-50-61-102"
+let defaults_w = "+a-4-9-20-29-40-41-42-50-61-102"
 let defaults_warn_error = "-a+5+6+101+109";;
 (*TODO: add +10*)


### PR DESCRIPTION
fixes #63

I'm not entirely sure why it started warning, but I'm:

1. attributing it to the OCaml version upgrades
2. turning it off by default because it should be portable in JS code.