### PR TITLE
React JSX PPX: generalize calling expressions to all identifiers

### DIFF
--- a/jscomp/test/dune.gen
+++ b/jscomp/test/dune.gen
@@ -6747,6 +6747,19 @@
 
 
   (rule
+    (targets reactjs_ppx_custom.cmi reactjs_ppx_custom.cmj reactjs_ppx_custom.js)
+    (deps (:inputs reactjs_ppx_custom.re) ../stdlib-412/stdlib.cmj)
+
+  (mode
+   (promote
+    (until-clean)
+    (only reactjs_ppx_custom.js)))
+
+    (action
+     (run bsc -bs-cmi -bs-cmj -bs-no-version-header  -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-60-67-68-106+104 -warn-error A  -I ../runtime -I ../stdlib-412/stdlib_modules -nopervasives -open Stdlib__no_aliases -I ../others -I . %{inputs})))
+
+
+  (rule
     (targets reasonReact.cmj reasonReact.js)
     (deps (:inputs reasonReact.re) ../stdlib-412/stdlib.cmj react.cmj reasonReact.cmi reasonReactOptimizedCreateClass.cmj reasonReactRouter.cmj)
 

--- a/jscomp/test/reactjs_ppx_custom.js
+++ b/jscomp/test/reactjs_ppx_custom.js
@@ -3,7 +3,15 @@
 var React = require("react");
 
 function Reactjs_ppx_custom$Internal$header(Props) {
-  return React.createElement("div", undefined);
+  throw {
+        RE_EXN_ID: "Assert_failure",
+        _1: [
+          "reactjs_ppx_custom.re",
+          5,
+          21
+        ],
+        Error: new Error()
+      };
 }
 
 var Internal = {

--- a/jscomp/test/reactjs_ppx_custom.js
+++ b/jscomp/test/reactjs_ppx_custom.js
@@ -1,0 +1,21 @@
+'use strict';
+
+var React = require("react");
+
+function Reactjs_ppx_custom$Internal$header(Props) {
+  return React.createElement("div", undefined);
+}
+
+var Internal = {
+  header: Reactjs_ppx_custom$Internal$header
+};
+
+function Reactjs_ppx_custom(Props) {
+  return React.createElement(Reactjs_ppx_custom$Internal$header, {});
+}
+
+var make = Reactjs_ppx_custom;
+
+exports.Internal = Internal;
+exports.make = make;
+/* react Not a pure module */

--- a/jscomp/test/reactjs_ppx_custom.re
+++ b/jscomp/test/reactjs_ppx_custom.re
@@ -1,0 +1,19 @@
+[@bs.config
+  {
+    flags: [|
+      "-bs-jsx",
+      "3",
+      "-dsource",
+      // "-w","A",
+      // "-warn-error", "a"
+    |],
+  }
+];
+
+module Internal = {
+  [@react.component]
+  let header = () => <div />;
+};
+
+[@react.component]
+let make = () => <Internal.header />;

--- a/jscomp/test/reactjs_ppx_custom.re
+++ b/jscomp/test/reactjs_ppx_custom.re
@@ -1,18 +1,8 @@
-[@bs.config
-  {
-    flags: [|
-      "-bs-jsx",
-      "3",
-      "-dsource",
-      // "-w","A",
-      // "-warn-error", "a"
-    |],
-  }
-];
+[@bs.config {flags: [|"-bs-jsx", "3"|]}];
 
 module Internal = {
   [@react.component]
-  let header = () => <div />;
+  let header = () => assert(false);
 };
 
 [@react.component]


### PR DESCRIPTION
- After https://github.com/reasonml/reason/pull/2541, Longidents are now being properly passed
- The React JSX PPX was relying on the previous, odd behavior, which appended `createElement` at the end of a long identifier.

This change relaxes the constraint that JSX calls need to end with `make` or `createElement`. The following case was affected:

```reason
module Internal = {
  [@react.component]
  let header = () => <div />;
};

[@react.component]
let make = () => <Internal.header />;
```

### Test plan

- Included a test case that failed to compile before this change.