### PR TITLE
Relativize include dirs

### DIFF
--- a/jscomp/bsb/bsb_build_util.ml
+++ b/jscomp/bsb/bsb_build_util.ml
@@ -58,15 +58,14 @@ let include_dirs_by dirs fn =
     (Ext_list.flat_map dirs (fun x -> ["-I"; maybe_quote_for_dune (fn x)]))
 
 
-let sourcedir_include_dirs ~per_proj_dir ~cur_dir ?namespace source_dirs =
+let rel_include_dirs ~per_proj_dir ~cur_dir ?namespace source_dirs =
  let relativize_single dir =
-  Ext_path.rel_normalized_absolute_path
-        ~from:(Ext_path.combine per_proj_dir cur_dir)
-        (Ext_path.combine per_proj_dir dir)
+   Ext_path.rel_normalized_absolute_path
+     ~from:(per_proj_dir // cur_dir)
+     (per_proj_dir // dir)
  in
  let source_dirs = Ext_list.map source_dirs relativize_single in
  let dirs = if namespace = None then source_dirs
-  (* TODO: add the lib/bs dir where the mlmap file is. *)
   else begin
    relativize_single Bsb_config.lib_bs :: source_dirs
   end

--- a/jscomp/bsb/bsb_build_util.mli
+++ b/jscomp/bsb/bsb_build_util.mli
@@ -57,7 +57,7 @@ val include_dirs_by :
   ('a -> string ) ->
   string
 
-val sourcedir_include_dirs :
+val rel_include_dirs :
   per_proj_dir:string ->
   cur_dir:string ->
   ?namespace:string ->

--- a/jscomp/bsb/bsb_config.ml
+++ b/jscomp/bsb/bsb_config.ml
@@ -40,6 +40,12 @@ let all_lib_artifacts =
   ]
 let rev_lib_bs = ".."// ".."
 
+let dune_build_dir = lazy (
+  match Sys.getenv_opt "DUNE_BUILD_DIR" with
+  | Some value -> value // "default"
+  | None -> "_build" // "default"
+)
+
 (* access the js directory from "lib/bs",
   it would be '../js'
 *)

--- a/jscomp/bsb/bsb_config.ml
+++ b/jscomp/bsb/bsb_config.ml
@@ -40,9 +40,6 @@ let all_lib_artifacts =
   ]
 let rev_lib_bs = ".."// ".."
 
-(* TODO: read current dune context *)
-let dune_build_dir = (Ext_path.combine "_build" "default")
-
 (* access the js directory from "lib/bs",
   it would be '../js'
 *)
@@ -81,7 +78,7 @@ let proj_rel path = rev_lib_bs // path
 let stdlib_path ~cwd =
   match Sys.getenv_opt "BSLIB" with
   | Some value -> value
-  | None -> 
+  | None ->
     let stdlib_path =
       Bsb_pkg.resolve_bs_package
         ~cwd

--- a/jscomp/bsb/bsb_config.mli
+++ b/jscomp/bsb/bsb_config.mli
@@ -39,4 +39,5 @@ val lib_bs_prefix_of_format : Ext_module_system.t -> string
 val top_prefix_of_format : Ext_module_system.t -> string
 (** default not install, only when -make-world, its dependencies will be installed  *)
 
+val dune_build_dir : string Lazy.t
 val stdlib_path : cwd:string -> string

--- a/jscomp/bsb/bsb_config.mli
+++ b/jscomp/bsb/bsb_config.mli
@@ -39,5 +39,4 @@ val lib_bs_prefix_of_format : Ext_module_system.t -> string
 val top_prefix_of_format : Ext_module_system.t -> string
 (** default not install, only when -make-world, its dependencies will be installed  *)
 
-val dune_build_dir : string
 val stdlib_path : cwd:string -> string

--- a/jscomp/bsb/bsb_config_parse.ml
+++ b/jscomp/bsb/bsb_config_parse.ml
@@ -27,15 +27,9 @@
 let (//) = Ext_path.combine
 
 let resolve_package cwd  package_name =
-  let package_path =  Bsb_pkg.resolve_bs_package ~cwd package_name  in
-  let rel = Ext_path.rel_normalized_absolute_path ~from:Bsb_global_paths.cwd package_path in
-  let package_install_path =
-    Bsb_global_paths.cwd // Bsb_config.dune_build_dir // rel
-  in
   {
     Bsb_config_types.package_name ;
-    package_path;
-    package_install_path;
+    package_path = Bsb_pkg.resolve_bs_package ~cwd package_name;
     package_dirs = [];
     package_install_dirs = [];
   }
@@ -403,8 +397,8 @@ and extract_dependencies ~package_kind (map : json_map) cwd (field : string )
      let { Bsb_config_types.file_groups = { files; _ }; namespace; _ } =
        interpret_json ~package_kind ~per_proj_dir:dep.package_path
      in
-     let ns_incl = Ext_option.map namespace (fun _ns ->
-       dep.package_install_path // Bsb_config.lib_bs)
+     let ns_incl =
+       Ext_option.map namespace (fun _ -> dep.package_path // Bsb_config.lib_bs)
      in
      let dirs = Ext_list.filter_map files (fun ({ Bsb_file_groups.dir; is_dev; _ } as group) ->
         if not is_dev && not (Bsb_file_groups.is_empty group) then
@@ -413,7 +407,7 @@ and extract_dependencies ~package_kind (map : json_map) cwd (field : string )
           None)
      in
      let install_dirs = Ext_list.filter_map files (fun { Bsb_file_groups.dir; is_dev; _ } ->
-        if not is_dev then Some (dep.package_install_path // dir) else None)
+        if not is_dev then Some (dep.package_path // dir) else None)
      in
      { dep with
        package_install_dirs = (match ns_incl with Some ns_incl -> ns_incl :: install_dirs | None -> install_dirs);

--- a/jscomp/bsb/bsb_config_types.ml
+++ b/jscomp/bsb/bsb_config_types.ml
@@ -27,7 +27,6 @@ type dependency =
   {
     package_name : Bsb_pkg_types.t ;
     package_path : string ;
-    package_install_path : string ;
     package_dirs : string list;
     package_install_dirs : string list;
   }

--- a/jscomp/bsb/bsb_ninja_gen.ml
+++ b/jscomp/bsb/bsb_ninja_gen.ml
@@ -40,25 +40,8 @@ let get_bsc_flags
   : string =
   String.concat Ext_string.single_space bsc_flags
 
-
-let bsc_lib_includes
-    (bs_dependencies : Bsb_config_types.dependencies)
-  (external_includes) =
-  (* TODO: bsc_flags contain stdlib path which is in the latter position currently *)
-  let all_includes  =
-    (Ext_list.flat_map bs_dependencies (fun x -> x.package_install_dirs)) @
-    (
-      (* for external includes, if it is absolute path, leave it as is
-         for relative path './xx', we need '../.././x' since we are in
-         [lib/bs], [build] is different from merlin though
-      *)
-      Ext_list.map
-        external_includes
-
-        (fun x -> if Filename.is_relative x then Bsb_config.rev_lib_bs_prefix  x else x)
-    )
-  in
-  Bsb_build_util.include_dirs all_includes
+let bsc_lib_includes (bs_dependencies : Bsb_config_types.dependencies) =
+  (Ext_list.flat_map bs_dependencies (fun x -> x.package_install_dirs))
 
 (* let output_static_resources
     (static_resources : string list)
@@ -220,12 +203,12 @@ let output_ninja_and_namespace_map
       ~bs_dep_parse:(Ext_filename.maybe_quote Bsb_global_paths.bs_dep_parse)
       ~warnings
       ~bsc_flags
-      ~g_dpkg_incls:(Bsb_build_util.include_dirs
-         (Ext_list.flat_map bs_dev_dependencies (fun x -> x.package_install_dirs)))
+      ~g_dpkg_incls:(bsc_lib_includes bs_dev_dependencies)
       ~g_dev_incls:source_dirs.dev
       ~g_stdlib_incl
       ~g_sourcedirs_incls:source_dirs.lib
-      ~g_lib_incls:(bsc_lib_includes bs_dependencies external_includes)
+      ~g_lib_incls:(bsc_lib_includes bs_dependencies)
+      ~external_incls:external_includes
       ~gentypeconfig:(Ext_option.map gentype_config (fun x ->
           ("-bs-gentype " ^ x.path)))
       ~pp_flags:(Ext_option.map pp_file Bsb_build_util.pp_flag)

--- a/jscomp/bsb/bsb_ninja_global_vars.ml
+++ b/jscomp/bsb/bsb_ninja_global_vars.ml
@@ -31,10 +31,11 @@ type t =
   bs_dep_parse: string;
   warnings: string;
   bsc_flags: string;
-  g_dpkg_incls: string;
+  g_dpkg_incls: string list;
   g_dev_incls: string list;
   g_stdlib_incl: string list;
-  g_lib_incls: string;
+  g_lib_incls: string list;
+  external_incls: string list;
   g_sourcedirs_incls: string list;
   gentypeconfig: string option;
   pp_flags: string option;
@@ -53,6 +54,7 @@ let make
   ~g_dev_incls
   ~g_stdlib_incl
   ~g_lib_incls
+  ~external_incls
   ~g_sourcedirs_incls
   ~gentypeconfig
   ~pp_flags
@@ -69,6 +71,7 @@ let make
   g_dev_incls;
   g_stdlib_incl;
   g_lib_incls;
+  external_incls;
   g_sourcedirs_incls;
   gentypeconfig;
   pp_flags;

--- a/jscomp/main/bsb_main.ml
+++ b/jscomp/main/bsb_main.ml
@@ -53,10 +53,8 @@ let bsb_main_flags : (string * spec * string) array =
     "Watch mode" ;
     (* XXX(anmonteiro): the two commands below do the same, and are kept for
        CLI compatibility. *)
-    (* TODO(anmonteiro): They should probably call `dune clean`. It could get
-       confusing why running `bsb -clean-world -make-world` doesn't rebuild
-       anything after a project is built (`Bsb_clean.clean` only removes the
-       files `bsb` wrote, it doesn't call `dune clean`). *)
+    (* TODO(anmonteiro): They call `dune clean` but they can't currently accept
+       dune flags (e.g. --root=.) *)
     "-clean-world", call_spec (fun _ ->
         Bsb_clean.clean  Bsb_global_paths.cwd),
     "Clean all bs dependencies";


### PR DESCRIPTION
- Previously we were including an absolute path to a "guessed" install directory
  - This relied on guessing that the dune build directory would be `_build/default`
- If we instead relativize the include paths then we don't have to care about where dune stores build artifacts at all
- unfortunately we still need to know where artifacts are going to end up in order to generate the dune file
  - I also refactored this code path to read `DUNE_BUILD_DIR` from the environment, if present.