### PR TITLE
Tell dune about directories starting with `_`

### DIFF
--- a/jscomp/bsb/bsb_config_parse.ml
+++ b/jscomp/bsb/bsb_config_parse.ml
@@ -344,7 +344,7 @@ let rec interpret_json
         let groups = Bsb_parse_sources.scan
             ~ignored_dirs:(extract_ignored_dirs map)
             ~package_kind
-            ~root: per_proj_dir
+            ~root:per_proj_dir
             ~cut_generators
             ~namespace
             sources in

--- a/jscomp/bsb/bsb_file_groups.ml
+++ b/jscomp/bsb/bsb_file_groups.ml
@@ -1,5 +1,5 @@
 (* Copyright (C) 2018- Hongbo Zhang, Authors of ReScript
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -17,41 +17,42 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
 
- type public = 
+ type public =
   | Export_none
-  | Export_all 
-  | Export_set of Set_string.t 
-  
+  | Export_all
+  | Export_set of Set_string.t
 
-type build_generator = 
+
+type build_generator =
   { input : string list ;
     output : string list;
-    command : string}  
+    command : string}
 
 
-type  file_group = 
+type  file_group =
   { dir : string ;
-    sources : Bsb_db.map; 
+    subdirs : string list;
+    sources : Bsb_db.map;
     resources : string list ;
     public : public ;
     is_dev : bool  ;
-    generators : build_generator list ; 
+    generators : build_generator list ;
     (* output of [generators] should be added to [sources],
        if it is [.ml,.mli,.re,.rei]
     *)
-  }     
+  }
 
-type file_groups = file_group list 
+type file_groups = file_group list
 
-type t =   
-  { files :  file_groups; 
-    globbed_dirs : string list ; 
+type t =
+  { files :  file_groups;
+    globbed_dirs : string list ;
   }
 
 
@@ -60,27 +61,27 @@ let empty : t = { files = []; globbed_dirs = [];  }
 
 
 
-let merge (u : t)  (v : t)  = 
-  if u == empty then v 
-  else if v == empty then u 
-  else 
+let merge (u : t)  (v : t)  =
+  if u == empty then v
+  else if v == empty then u
+  else
     {
-      files = Ext_list.append u.files  v.files ; 
-      globbed_dirs = Ext_list.append u.globbed_dirs  v.globbed_dirs ; 
-    }  
+      files = Ext_list.append u.files  v.files ;
+      globbed_dirs = Ext_list.append u.globbed_dirs  v.globbed_dirs ;
+    }
 
-let cons ~file_group ?globbed_dir (v : t) : t =  
+let cons ~file_group ?globbed_dir (v : t) : t =
   {
     files = file_group :: v.files;
-    globbed_dirs = 
-      match globbed_dir with 
+    globbed_dirs =
+      match globbed_dir with
       | None -> v.globbed_dirs
       | Some f -> f :: v.globbed_dirs
   }
 (** when [is_empty file_group]
     we don't need issue [-I] [-S] in [.merlin] file
-*)  
-let is_empty (x : file_group) = 
+*)
+let is_empty (x : file_group) =
   Map_string.is_empty x.sources &&
   x.resources = [] &&
-  x.generators = []    
+  x.generators = []

--- a/jscomp/bsb/bsb_file_groups.mli
+++ b/jscomp/bsb/bsb_file_groups.mli
@@ -1,5 +1,5 @@
 (* Copyright (C) 2018- Hongbo Zhang, Authors of ReScript
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -17,58 +17,59 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
 
- type public = 
+ type public =
   | Export_none
-  | Export_all 
-  | Export_set of Set_string.t 
-  
+  | Export_all
+  | Export_set of Set_string.t
 
-type build_generator = 
+
+type build_generator =
   { input : string list ;
     output : string list;
-    command : string}  
+    command : string}
 
 
-type  file_group = 
+type  file_group =
   { dir : string ;
-    sources : Bsb_db.map; 
+    subdirs : string list;
+    sources : Bsb_db.map;
     resources : string list ;
     public : public ;
     is_dev : bool ; (* false means not in dev mode *)
-    generators : build_generator list ; 
+    generators : build_generator list ;
     (* output of [generators] should be added to [sources],
        if it is [.ml,.mli,.re,.rei]
     *)
-  }     
-
-type file_groups = file_group list 
-
-type t 
-  = private
-  { files :  file_groups; 
-    globbed_dirs : string list ; 
   }
 
-val empty : t    
+type file_groups = file_group list
 
-val merge : 
-  t -> 
-  t -> 
-  t   
+type t
+  = private
+  { files :  file_groups;
+    globbed_dirs : string list ;
+  }
 
-val cons :   
+val empty : t
+
+val merge :
+  t ->
+  t ->
+  t
+
+val cons :
   file_group:file_group ->
   ?globbed_dir:string ->
   t ->
   t
 
-val is_empty :   
+val is_empty :
   file_group ->
   bool
 

--- a/jscomp/bsb/bsb_ninja_file_groups.ml
+++ b/jscomp/bsb/bsb_ninja_file_groups.ml
@@ -196,6 +196,13 @@ let handle_files_per_dir
     Buffer.add_string buf "(subdir ";
     Buffer.add_string buf rel_group_dir;
     Buffer.add_char buf '\n';
+    if group.subdirs <> [] then begin
+      Buffer.add_string buf "(dirs :standard";
+      Ext_list.iter group.subdirs (fun subdir ->
+        Buffer.add_char buf ' ';
+        Buffer.add_string buf subdir);
+      Buffer.add_string buf ")\n"
+    end;
     let is_dev = group.is_dev in
     handle_generators buf group rules.customs ;
     let installable =

--- a/jscomp/bsb/bsb_ninja_gen.ml
+++ b/jscomp/bsb/bsb_ninja_gen.ml
@@ -246,7 +246,6 @@ let output_ninja_and_namespace_map
   (** Generate build statement for each file *)
   Ext_list.iter bs_file_groups
     (fun files_per_dir ->
-      (* let group_dir = global_config.src_root_dir // files_per_dir.dir in *)
        Bsb_ninja_file_groups.handle_files_per_dir buf
          ~global_config
          ~rules
@@ -256,8 +255,7 @@ let output_ninja_and_namespace_map
          ~bs_dev_dependencies
          ~bs_dependencies
          ~root_dir
-         files_per_dir;
-         )
+         files_per_dir)
   ;
 
   Buffer.add_char buf '\n';


### PR DESCRIPTION
- Dune ignores subdirectories that start with `_`
- `__tests__` is a common one that people have in their projects
- this change tells dune about subdirectories that should be included based on what gets passed to `subdirs: ...` in `bsconfig.json`

fixes #70